### PR TITLE
Tune status bar layout for Qin 3 Ultra

### DIFF
--- a/DuoQin/Qin3Ultra-SystemUI/res/values/config.xml
+++ b/DuoQin/Qin3Ultra-SystemUI/res/values/config.xml
@@ -2,9 +2,10 @@
 <resources>
     <dimen name="status_bar_padding_start">23px</dimen>
     <dimen name="status_bar_padding_end">37px</dimen>
-    <dimen name="status_bar_header_height_keyguard">137px</dimen>
-    <dimen name="keyguard_carrier_text_margin">23px</dimen>
+    <dimen name="status_bar_padding_top">27px</dimen>
+    <dimen name="status_bar_header_height_keyguard">110px</dimen>
+    <dimen name="keyguard_carrier_text_margin">124px</dimen>
     <dimen name="system_icons_keyguard_padding_end">37px</dimen>
-    <dimen name="large_screen_shade_header_height">137px</dimen>
-    <dimen name="large_screen_shade_header_min_height">137px</dimen>
+    <dimen name="large_screen_shade_header_height">110px</dimen>
+    <dimen name="large_screen_shade_header_min_height">110px</dimen>
 </resources>

--- a/DuoQin/Qin3Ultra/res/values/config.xml
+++ b/DuoQin/Qin3Ultra/res/values/config.xml
@@ -4,11 +4,11 @@
     <bool name="config_showNavigationBar">true</bool>
     <bool name="config_fillMainBuiltInDisplayCutout">false</bool>
 
-    <dimen name="status_bar_height_default">137px</dimen>
-    <dimen name="status_bar_height">137px</dimen>
-    <dimen name="status_bar_height_portrait">137px</dimen>
+    <dimen name="status_bar_height_default">110px</dimen>
+    <dimen name="status_bar_height">110px</dimen>
+    <dimen name="status_bar_height_portrait">110px</dimen>
     <dimen name="status_bar_height_landscape">28dp</dimen>
-    <dimen name="quick_qs_offset_height">137px</dimen>
+    <dimen name="quick_qs_offset_height">110px</dimen>
 
     <integer name="config_screenBrightnessSettingMinimum">1</integer>
 


### PR DESCRIPTION
- Reduce the height of status bar
- Pad the top of status bar so that the text aligns with the front-facing camera.
- keyguard_carrier_text_margin needs to include padding induced by cutout; otherwise it is going to be reset to 0 in fwb.