### PR TITLE
Update Galaxy A32 4G Overlays

### DIFF
--- a/Samsung/A32-SystemUI/res/values/bools.xml
+++ b/Samsung/A32-SystemUI/res/values/bools.xml
@@ -5,5 +5,5 @@
     <bool name="doze_proximity_check_before_pulse">false</bool>
     <bool name="doze_pulse_on_notifications">true</bool>
     <bool name="doze_single_tap_uses_prox">false</bool>
-    <bool name="doze_suspend_display_state_supported">true</bool>
+    <bool name="doze_suspend_display_state_supported">false</bool>
 </resources>

--- a/Samsung/A32-SystemUI/res/values/dimens.xml
+++ b/Samsung/A32-SystemUI/res/values/dimens.xml
@@ -7,5 +7,5 @@
     <dimen name="status_bar_icon_padding">2dp</dimen>
     <dimen name="status_bar_padding_top">4dp</dimen>
     <item name="proximity_sensor_threshold" translatable="false" format="float" type="dimen">5</item>
-    <dimen name="physical_power_button_center_screen_location_y">1150px</dimen>
+    <dimen name="physical_power_button_center_screen_location_y">1050px</dimen>
 </resources>

--- a/Samsung/A32/res/values/bools.xml
+++ b/Samsung/A32/res/values/bools.xml
@@ -17,4 +17,5 @@
     <bool name="skip_restoring_network_selection">true</bool>
     <bool name="config_displayBlanksAfterDoze">false</bool>
     <bool name="config_enableBurnInProtection">true</bool>
+    <bool name="config_supportDoubleTapWake">true</bool>
 </resources>

--- a/Samsung/A32/res/values/bools.xml
+++ b/Samsung/A32/res/values/bools.xml
@@ -15,4 +15,6 @@
     <bool name="config_switch_phone_on_voice_reg_state_change">false</bool>
     <bool name="config_useDevInputEventForAudioJack">true</bool>
     <bool name="skip_restoring_network_selection">true</bool>
+    <bool name="config_displayBlanksAfterDoze">false</bool>
+    <bool name="config_enableBurnInProtection">true</bool>
 </resources>

--- a/Samsung/A32/res/values/integers.xml
+++ b/Samsung/A32/res/values/integers.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <integer name="config_screenBrightnessDoze">5</integer>
+    <integer name="config_screenBrightnessDoze">85</integer>
     <integer name="config_screenBrightnessDim">12</integer>
     <integer name="config_screenBrightnessSettingDefault">128</integer>
     <integer name="config_screenBrightnessSettingMaximum">255</integer>
     <integer name="config_screenBrightnessSettingMinimum">0</integer>
-    <integer name="config_burnInProtectionMaxRadius">70</integer>
-    <integer name="config_burnInProtectionMinHorizontalOffset">-15</integer>
-    <integer name="config_burnInProtectionMaxHorizontalOffset">15</integer>
-    <integer name="config_burnInProtectionMinVerticalOffset">-40</integer>
-    <integer name="config_burnInProtectionMaxVerticalOffset">40</integer>
+    <integer name="config_burnInProtectionMaxRadius">100</integer>
+    <integer name="config_burnInProtectionMinHorizontalOffset">-50</integer>
+    <integer name="config_burnInProtectionMaxHorizontalOffset">50</integer>
+    <integer name="config_burnInProtectionMinVerticalOffset">-70</integer>
+    <integer name="config_burnInProtectionMaxVerticalOffset">70</integer>
 </resources>

--- a/Samsung/A32/res/values/integers.xml
+++ b/Samsung/A32/res/values/integers.xml
@@ -5,4 +5,9 @@
     <integer name="config_screenBrightnessSettingDefault">128</integer>
     <integer name="config_screenBrightnessSettingMaximum">255</integer>
     <integer name="config_screenBrightnessSettingMinimum">0</integer>
+    <integer name="config_burnInProtectionMaxRadius">70</integer>
+    <integer name="config_burnInProtectionMinHorizontalOffset">-15</integer>
+    <integer name="config_burnInProtectionMaxHorizontalOffset">15</integer>
+    <integer name="config_burnInProtectionMinVerticalOffset">-40</integer>
+    <integer name="config_burnInProtectionMaxVerticalOffset">40</integer>
 </resources>


### PR DESCRIPTION
This phone had an issue where the Always on display would get stuck and would not update. I have fixed it with these issues. I have built these overlays and tested them and they work fine. I have also realigned the power button so that the animation b/w aod and lock screen clock goes to the power button. Also enabled misc configs and added burn in protection. This is all tested and i am currently manually pushing them into their respective directories until this has been merged and included by default in newer gsi;s.