### PR TITLE
Add overlay for Samsung Galaxy A02s (a02q)

### DIFF
--- a/Samsung/a02q-SystemUI/Android.mk
+++ b/Samsung/a02q-SystemUI/Android.mk
@@ -1,0 +1,8 @@
+LOCAL_PATH := $(call my-dir)
+include $(CLEAR_VARS)
+LOCAL_MODULE_TAGS := optional
+LOCAL_PACKAGE_NAME := treble-overlay-samsung-a02q-systemui
+LOCAL_MODULE_PATH := $(TARGET_OUT_PRODUCT)/overlay
+LOCAL_IS_RUNTIME_RESOURCE_OVERLAY := true
+LOCAL_PRIVATE_PLATFORM_APIS := true
+include $(BUILD_PACKAGE)

--- a/Samsung/a02q-SystemUI/AndroidManifest.xml
+++ b/Samsung/a02q-SystemUI/AndroidManifest.xml
@@ -1,0 +1,10 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+        package="me.phh.treble.overlay.samsung.a02q.systemui"
+        android:versionCode="1"
+        android:versionName="1.0">
+        <overlay android:targetPackage="com.android.systemui"
+        	android:requiredSystemPropertyName="ro.vendor.build.fingerprint"
+        	android:requiredSystemPropertyValue="+*samsung/a02q*"
+		android:priority="483"
+		android:isStatic="true"/>
+</manifest>

--- a/Samsung/a02q-SystemUI/res/values/config.xml
+++ b/Samsung/a02q-SystemUI/res/values/config.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="status_bar_padding_start">32.0px</dimen>
+</resources>

--- a/Samsung/a02q/Android.mk
+++ b/Samsung/a02q/Android.mk
@@ -1,0 +1,8 @@
+LOCAL_PATH := $(call my-dir)
+include $(CLEAR_VARS)
+LOCAL_MODULE_TAGS := optional
+LOCAL_PACKAGE_NAME := treble-overlay-samsung-a02q
+LOCAL_MODULE_PATH := $(TARGET_OUT_PRODUCT)/overlay
+LOCAL_IS_RUNTIME_RESOURCE_OVERLAY := true
+LOCAL_PRIVATE_PLATFORM_APIS := true
+include $(BUILD_PACKAGE)

--- a/Samsung/a02q/AndroidManifest.xml
+++ b/Samsung/a02q/AndroidManifest.xml
@@ -1,0 +1,10 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+        package="me.phh.treble.overlay.samsung.a02q"
+        android:versionCode="1"
+        android:versionName="1.0">
+        <overlay android:targetPackage="android"
+        android:requiredSystemPropertyName="ro.vendor.build.fingerprint"
+        android:requiredSystemPropertyValue="+samsung/a02q*"
+		android:priority="357"
+		android:isStatic="true" />
+</manifest>

--- a/Samsung/a02q/res/values/arrays.xml
+++ b/Samsung/a02q/res/values/arrays.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <integer-array name="config_autoBrightnessLcdBacklightValues">
+        <item>3</item>
+        <item>35</item>
+        <item>53</item>
+        <item>60</item>
+        <item>65</item>
+        <item>77</item>
+        <item>115</item>
+        <item>179</item>
+        <item>230</item>
+        <item>255</item>
+    </integer-array>
+    <integer-array name="config_autoBrightnessLevels">
+        <item>20</item>
+        <item>50</item>
+        <item>100</item>
+        <item>200</item>
+        <item>400</item>
+        <item>1000</item>
+        <item>2000</item>
+        <item>3000</item>
+        <item>5000</item>
+    </integer-array>
+    <string-array name="config_tether_wifi_regexs">
+        <item>wigig0</item>
+        <item>wlan0</item>
+    </string-array>
+</resources>

--- a/Samsung/a02q/res/values/bools.xml
+++ b/Samsung/a02q/res/values/bools.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="config_dozeAfterScreenOff">true</bool>
+    <bool name="config_powerDecoupleInteractiveModeFromDisplay">false</bool>
+    <bool name="config_setColorTransformAccelerated">true</bool>
+    <bool name="config_supportAudioSourceUnprocessed">false</bool>
+    <bool name="config_suspendWhenScreenOffDueToProximity">true</bool>
+</resources>

--- a/Samsung/a02q/res/values/dimens.xml
+++ b/Samsung/a02q/res/values/dimens.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="status_bar_height_portrait">45.0px</dimen>
+    <dimen name="rounded_corner_radius">30.0px</dimen>
+</resources>

--- a/Samsung/a02q/res/values/integers.xml
+++ b/Samsung/a02q/res/values/integers.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <integer name="config_screenBrightnessDoze">17</integer>
+</resources>

--- a/Samsung/a02q/res/values/strings.xml
+++ b/Samsung/a02q/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="config_mainBuiltInDisplayCutout">M 0,0 H -88 V 45 H 88 V 0 H 0 Z</string>
+</resources>

--- a/Samsung/a02q/res/xml/power_profile.xml
+++ b/Samsung/a02q/res/xml/power_profile.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<device name="Android">
+    <item name="screen.on">63</item>
+    <item name="screen.full">261</item>
+    <array name="cpu.speeds">
+        <value>200000</value>
+        <value>499200</value>
+        <value>533333</value>
+        <value>800000</value>
+        <value>998400</value>
+        <value>1094400</value>
+        <value>1209600</value>
+    </array>
+    <array name="cpu.active">
+        <value>151</value>
+        <value>169</value>
+        <value>177</value>
+        <value>195</value>
+        <value>259</value>
+        <value>307</value>
+        <value>353</value>
+    </array>
+    <item name="cpu.awake">1.6</item>
+    <item name="cpu.idle">1.6</item>
+    <item name="battery.capacity">4900</item>
+    <item name="battery.typical.capacity">5000</item>
+</device>

--- a/overlay.mk
+++ b/overlay.mk
@@ -190,6 +190,8 @@ PRODUCT_PACKAGES += \
 	treble-overlay-samsung-S20-systemui \
 	treble-overlay-samsung-S20fe \
 	treble-overlay-samsung-S20fe-systemui \
+	treble-overlay-samsung-a02q \
+	treble-overlay-samsung-a02q-systemui \
 	treble-overlay-samsung-a20 \
 	treble-overlay-samsung-a20s \
 	treble-overlay-samsung-a20s-systemui \


### PR DESCRIPTION
Overlay has been created to fix issues such as battery capacity, notch, rounded corners and brightness.

Framework-res (from which the right configs for the device was found) didn't have any config for rounded corners. But since the device's display has rounded corners, I decided to add the value by my own to fix it. However, the value is inaccurate and I'll tweak it in the future once I find the right value for it.

System-UI overlay has been created to fix the status bar since the left side of it was a little bit off. So, I decided to move it a little bit.

The power_profile does seems small but this is what contained the right capacity for the battery so I decided to take it.