### PR TITLE
Enable AOD for Asus Rog Phone (Z01QD)

### DIFF
--- a/Asus/RogPhone-SystemUI/Android.mk
+++ b/Asus/RogPhone-SystemUI/Android.mk
@@ -1,0 +1,8 @@
+LOCAL_PATH := $(call my-dir)
+include $(CLEAR_VARS)
+LOCAL_MODULE_TAGS := optional
+LOCAL_PACKAGE_NAME := treble-overlay-asus-rogphone-systemui
+LOCAL_MODULE_PATH := $(TARGET_OUT_PRODUCT)/overlay
+LOCAL_IS_RUNTIME_RESOURCE_OVERLAY := true
+LOCAL_PRIVATE_PLATFORM_APIS := true
+include $(BUILD_PACKAGE)

--- a/Asus/RogPhone-SystemUI/AndroidManifest.xml
+++ b/Asus/RogPhone-SystemUI/AndroidManifest.xml
@@ -1,0 +1,10 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+        package="me.phh.treble.overlay.asus.rogphone.systemui"
+        android:versionCode="1"
+        android:versionName="1.0">
+        <overlay android:targetPackage="com.android.systemui"
+                android:requiredSystemPropertyName="ro.vendor.build.fingerprint"
+                android:requiredSystemPropertyValue="+*ASUS_Z01QD_1*"
+		android:priority="626"
+                android:isStatic="true" />
+</manifest>

--- a/Asus/RogPhone-SystemUI/res/values/config.xml
+++ b/Asus/RogPhone-SystemUI/res/values/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="doze_display_state_supported">false</bool>
+    <bool name="doze_suspend_display_state_supported">false</bool>
+</resources>

--- a/Asus/RogPhone/res/values/config.xml
+++ b/Asus/RogPhone/res/values/config.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <bool name="config_dozeAlwaysOnDisplayAvailable">true</bool>
+    <bool name="config_powerDecoupleInteractiveModeFromDisplay">true</bool>
+    <bool name="config_dozeAfterScreenOff">true</bool>
     <bool name="config_automatic_brightness_available">true</bool>
     <bool name="config_showNavigationBar">true</bool>
 
@@ -9,7 +12,7 @@
 
     <integer name="config_screenBrightnessDark">1</integer>
     <integer name="config_screenBrightnessDim">10</integer>
-    <integer name="config_screenBrightnessDoze">17</integer>
+    <integer name="config_screenBrightnessDoze">7</integer>
     <integer name="config_screenBrightnessSettingMinimum">1</integer>
     <integer name="config_screenBrightnessSettingDefault">63</integer>
     <integer name="config_screenBrightnessSettingMaximum">255</integer>

--- a/Asus/RogPhone/res/values/config.xml
+++ b/Asus/RogPhone/res/values/config.xml
@@ -5,6 +5,9 @@
     <bool name="config_dozeAfterScreenOff">true</bool>
     <bool name="config_automatic_brightness_available">true</bool>
     <bool name="config_showNavigationBar">true</bool>
+    <bool name="config_bluetooth_le_peripheral_mode_supported">true</bool>
+    <bool name="config_wifiDisplaySupportsProtectedBuffers">true</bool>
+    <bool name="config_supportAudioSourceUnprocessed">true</bool>
 
     <fraction name="config_autoBrightnessAdjustmentMaxGamma">300.0%</fraction>
     <fraction name="config_screenAutoBrightnessDozeScaleFactor">100.0%</fraction>

--- a/overlay.mk
+++ b/overlay.mk
@@ -7,6 +7,7 @@ PRODUCT_PACKAGES += \
 	treble-overlay-SystemUI-FalseLocks \
 	treble-overlay-Telephony-LTE \
 	treble-overlay-asus-rogphone \
+	treble-overlay-asus-rogphone-systemui \
 	treble-overlay-asus-zenfone5 \
 	treble-overlay-asus-zenfone5-10 \
 	treble-overlay-asus-zenfone5z \


### PR DESCRIPTION
* Enable AOD without doze display state, and adjust brightness.
* While at it, add some overlays pulled from stock.