### PR TITLE
Add overlay for Lenovo Xiaoxin Pad Pro 2021

### DIFF
--- a/Lenovo/P11ProPlus/Android.mk
+++ b/Lenovo/P11ProPlus/Android.mk
@@ -1,0 +1,8 @@
+LOCAL_PATH := $(call my-dir)
+include $(CLEAR_VARS)
+LOCAL_MODULE_TAGS := optional
+LOCAL_PACKAGE_NAME := treble-overlay-lenovo-p11_pro_plus
+LOCAL_MODULE_PATH := $(TARGET_OUT_PRODUCT)/overlay
+LOCAL_IS_RUNTIME_RESOURCE_OVERLAY := true
+LOCAL_PRIVATE_PLATFORM_APIS := true
+include $(BUILD_PACKAGE)

--- a/Lenovo/P11ProPlus/AndroidManifest.xml
+++ b/Lenovo/P11ProPlus/AndroidManifest.xml
@@ -1,0 +1,10 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+        package="me.phh.treble.overlay.lenovo.p11_pro_plus"
+        android:versionCode="1"
+        android:versionName="1.0">
+        <overlay android:targetPackage="android"
+                android:requiredSystemPropertyName="ro.product.vendor.device"
+                android:requiredSystemPropertyValue="p11_pro_plus"
+		android:priority="767"
+		android:isStatic="true" />
+</manifest>

--- a/Lenovo/P11ProPlus/res/values/arrays.xml
+++ b/Lenovo/P11ProPlus/res/values/arrays.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <integer-array name="config_autoBrightnessLevels">
+        <item>10</item>
+        <item>30</item>
+        <item>60</item>
+        <item>90</item>
+        <item>150</item>
+        <item>200</item>
+        <item>350</item>
+        <item>450</item>
+        <item>550</item>
+        <item>720</item>
+        <item>950</item>
+        <item>1100</item>
+        <item>1500</item>
+        <item>2000</item>
+        <item>3500</item>
+    </integer-array>
+    <integer-array name="config_screenBrightnessBacklight">
+        <item>25</item>
+        <item>45</item>
+        <item>76</item>
+        <item>120</item>
+        <item>145</item>
+        <item>195</item>
+        <item>230</item>
+        <item>240</item>
+        <item>255</item>
+    </integer-array>
+    <integer-array name="config_screenBrightnessNits">
+        <item>6</item>
+        <item>13</item>
+        <item>30</item>
+        <item>80</item>
+        <item>119</item>
+        <item>224</item>
+        <item>320</item>
+        <item>351</item>
+        <item>420</item>
+    </integer-array>
+    <integer-array name="config_autoBrightnessDisplayValuesNits">
+        <item>10</item>
+        <item>45</item>
+        <item>65</item>
+        <item>85</item>
+        <item>85</item>
+        <item>85</item>
+        <item>110</item>
+        <item>140</item>
+        <item>180</item>
+        <item>210</item>
+        <item>250</item>
+        <item>280</item>
+        <item>320</item>
+        <item>340</item>
+        <item>360</item>
+        <item>420</item>
+    </integer-array>
+</resources>

--- a/Lenovo/P11ProPlus/res/values/bools.xml
+++ b/Lenovo/P11ProPlus/res/values/bools.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="config_automatic_brightness_available">true</bool>
+    <bool name="config_bluetooth_hfp_inband_ringing_support">true</bool>
+    <bool name="config_bluetooth_le_peripheral_mode_supported">true</bool>
+    <bool name="config_carrier_volte_available">true</bool>
+    <bool name="config_device_volte_available">true</bool>
+    <bool name="config_device_vt_available">true</bool>
+    <bool name="config_device_wfc_ims_available">true</bool>
+    <bool name="config_dozeAfterScreenOff">true</bool>
+    <bool name="config_hotswapCapable">true</bool>
+    <bool name="config_setColorTransformAccelerated">true</bool>
+    <bool name="config_speed_up_audio_on_mt_calls">true</bool>
+    <bool name="config_supportAudioSourceUnprocessed">true</bool>
+    <bool name="config_switch_phone_on_voice_reg_state_change">false</bool>
+    <bool name="config_wifiDisplaySupportsProtectedBuffers">true</bool>
+    <bool name="config_wifi_background_scan_support">true</bool>
+    <bool name="config_wifi_batched_scan_supported">true</bool>
+    <bool name="config_wifi_connected_mac_randomization_supported">true</bool>
+    <bool name="config_wifi_dual_band_support">true</bool>
+    <bool name="config_wifi_p2p_mac_randomization_supported">true</bool>
+    <bool name="skip_restoring_network_selection">true</bool>
+</resources>

--- a/Lenovo/P11ProPlus/res/values/integers.xml
+++ b/Lenovo/P11ProPlus/res/values/integers.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <integer name="config_defaultPeakRefreshRate">120</integer>
+    <integer name="config_defaultRefreshRate">0</integer>
+    <integer name="config_screenBrightnessDoze">17</integer>
+    <integer name="config_screenBrightnessSettingMaximum">255</integer>
+    <integer name="config_screenBrightnessSettingMinimum">29</integer>
+</resources>

--- a/Lenovo/P11ProPlus/res/xml/power_profile.xml
+++ b/Lenovo/P11ProPlus/res/xml/power_profile.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="utf-8"?>
+<device name="Android">
+    <item name="battery.capacity">8400</item>
+    <item name="screen.on">79.01</item>
+    <item name="screen.full">479.19</item>
+    <item name="camera.flashlight">158</item>
+    <item name="camera.avg">300</item>
+    <item name="video">53.25</item>
+    <item name="audio">35.94</item>
+    <array name="cpu.clusters.cores">
+        <value>6</value>
+        <value>2</value>
+    </array>
+    <item name="cpu.suspend">5.43</item>
+    <item name="cpu.idle">3.61</item>
+    <item name="cpu.active">19.87</item>
+    <item name="cpu.cluster_power.cluster0">12</item>
+    <item name="cpu.cluster_power.cluster1">12</item>
+    <array name="cpu.core_speeds.cluster0">
+        <value>300000</value>
+        <value>576000</value>
+        <value>768000</value>
+        <value>1017600</value>
+        <value>1248000</value>
+        <value>1324800</value>
+        <value>1497600</value>
+        <value>1612800</value>
+        <value>1708800</value>
+        <value>1804800</value>
+    </array>
+    <array name="cpu.core_power.cluster0">
+        <value>11</value>
+        <value>23</value>
+        <value>28</value>
+        <value>43</value>
+        <value>52</value>
+        <value>79</value>
+        <value>90</value>
+        <value>108</value>
+        <value>128</value>
+        <value>149</value>
+    </array>
+    <array name="cpu.core_speeds.cluster1">
+        <value>300000</value>
+        <value>652800</value>
+        <value>806400</value>
+        <value>979200</value>
+        <value>1094400</value>
+        <value>1209600</value>
+        <value>1324800</value>
+        <value>1555200</value>
+        <value>1708800</value>
+        <value>1843200</value>
+        <value>1939200</value>
+        <value>2169600</value>
+        <value>2208000</value>
+    </array>
+    <array name="cpu.core_power.cluster1">
+        <value>243</value>
+        <value>297</value>
+        <value>312</value>
+        <value>362</value>
+        <value>389</value>
+        <value>448</value>
+        <value>586</value>
+        <value>696</value>
+        <value>876</value>
+        <value>900</value>
+        <value>948</value>
+        <value>1180</value>
+        <value>1300</value>
+    </array>
+    <item name="cpu.awake">1.6</item>
+    <item name="wifi.controller.idle">2</item>
+    <item name="wifi.controller.rx">140</item>
+    <item name="wifi.controller.tx">260</item>
+    <item name="wifi.controller.voltage">3700</item>
+    <item name="modem.controller.sleep">0</item>
+    <item name="modem.controller.idle">3</item>
+    <item name="modem.controller.rx">150</item>
+    <array name="modem.controller.tx">
+        <value>150</value>
+        <value>180</value>
+        <value>230</value>
+        <value>300</value>
+        <value>390</value>
+    </array>
+    <item name="modem.controller.voltage">3700</item>
+    <array name="gps.signalqualitybased">
+        <value>49</value>
+        <value>8</value>
+    </array>
+    <item name="gps.voltage">3700</item>
+    <item name="bluetooth.controller.idle">0.01</item>
+    <item name="bluetooth.controller.rx">9</item>
+    <item name="bluetooth.controller.tx">7</item>
+    <item name="bluetooth.controller.voltage">3300</item>
+</device>

--- a/overlay.mk
+++ b/overlay.mk
@@ -65,6 +65,7 @@ PRODUCT_PACKAGES += \
 	treble-overlay-lenovo-Q706F \
 	treble-overlay-lenovo-Y70 \
 	treble-overlay-lenovo-k5pro \
+	treble-overlay-lenovo-p11_pro_plus \
 	treble-overlay-lenovo-s5 \
 	treble-overlay-lenovo-s5pro \
 	treble-overlay-lenovo-tabv7 \


### PR DESCRIPTION
Add an overlay for the Lenovo Xiaoxin Pad Pro 2021 (TB-J716F) to fix automatic brightness.

Issues remaining:
- Default screen orientation
- ~~Hall effect sensor for flip cover~~ See TrebleDroid/treble_app#18