### PR TITLE
Fix overlay not getting applied on some ROMs in Camon 20 Pro 4G and Pova 4 Pro

### DIFF
--- a/Tecno/Camon20Pro4G/AndroidManifest.xml
+++ b/Tecno/Camon20Pro4G/AndroidManifest.xml
@@ -3,8 +3,8 @@
         android:versionCode="1"
         android:versionName="1.0">
         <overlay android:targetPackage="android"
-                android:requiredSystemPropertyName="ro.vendor.build.fingerprint"
-		android:requiredSystemPropertyValue="+TECNO/CK7n*"
+                android:requiredSystemPropertyName="ro.product.vendor.device"
+		android:requiredSystemPropertyValue="TECNO-CK7n"
 		android:priority="439"
 		android:isStatic="true" />
 </manifest>

--- a/Tecno/Pova4Pro/AndroidManifest.xml
+++ b/Tecno/Pova4Pro/AndroidManifest.xml
@@ -3,8 +3,8 @@
         android:versionCode="1"
         android:versionName="1.0">
         <overlay android:targetPackage="android"
-                android:requiredSystemPropertyName="ro.vendor.build.fingerprint"
-		android:requiredSystemPropertyValue="+TECNO/LG8n*"
+                android:requiredSystemPropertyName="ro.product.vendor.device"
+		android:requiredSystemPropertyValue="TECNO-LG8n"
 		android:priority="634"
 		android:isStatic="true" />
 </manifest>


### PR DESCRIPTION
Fixes overlay not being applied in some ROMs like AncientOS and SuperiorOS


This shouldn't affect any  ROMs where the overlay works fine without this commit

Tested on Ancient OS(DSU) and VoltageOS(My current running GSI)