### PR TITLE
fix: add CorvusOS's build fingerprint for LG V50 (flashlmdd)

### DIFF
--- a/LG/lm_v500n/AndroidManifest.xml
+++ b/LG/lm_v500n/AndroidManifest.xml
@@ -4,7 +4,7 @@
         android:versionName="1.0">
         <overlay android:targetPackage="android"
                 android:requiredSystemPropertyName="ro.vendor.build.fingerprint"
-                android:requiredSystemPropertyValue="+lge/flashlmdd_lao_com/flashlmdd*"
+                android:requiredSystemPropertyValue="+lge/(corvus_flashlmdd|flashlmdd_lao_com)/flashlmdd*"
 		android:priority="196"
 		android:isStatic="true" />
 </manifest>

--- a/LG/lm_v500n/AndroidManifest.xml
+++ b/LG/lm_v500n/AndroidManifest.xml
@@ -4,7 +4,7 @@
         android:versionName="1.0">
         <overlay android:targetPackage="android"
                 android:requiredSystemPropertyName="ro.vendor.build.fingerprint"
-                android:requiredSystemPropertyValue="+lge/(corvus_flashlmdd|flashlmdd_lao_com)/flashlmdd*"
+                android:requiredSystemPropertyValue="+lge/*flashlmdd*"
 		android:priority="196"
 		android:isStatic="true" />
 </manifest>


### PR DESCRIPTION
This PR adds an OR condition for the check on flashlmdd's build fingerprint to support CorvusOS's last official release build fingerprint (`lge/corvus_flashlmdd/flashlmdd:13/TD1A.221105.001/1668359496:user/release-keys`) in addition to the one from the stock firmware from LGE.

Now, the (obvious) question:
## Why would anyone do this?
See, the issue with using LG's stock vendor is that some functionality breaks under most if not all GSIs:
- The Assistant key is, for some reason, mapped to `INFO`, not `ASSIST` using LG's stock vendor, causing it to not work on basically anything
- Vibration, which is managed by the LG daemon `immvibed`, straight up does not work. That daemon appears to check for device build fingerprint, OEM and even the Android version before it would do anything with the vibration motor.
- Not all cameras work (this device have 5: 2 front, 3 back). For some reason the back telephoto and front UW doesn't show up
- The back side notification light (the 5G logo) doesn't actually work as a notification light (it just cycles uncontrolled)

By using Corvus as a base, GSIs benefits from:
- A newer Vendor implementation (VNDK 33, Android 13 based) 
- Mentioned features works as expected
- Actually have a unique enough build strings. Another ROM (ricedroid 8.0) that is commonly used as a GSI base uses `cheetah` in its fingerprint `google/cheetah/cheetah:13/TD1A.221105.003/9229241:user/release-keys`, no good for identifying what the device.

I'm fairly sure this may break a rule *somewhere* with overlays, but gonna attempt to PR this anyway, since it does improves the general experience for GSIs on these devices