### PR TITLE
Add overlay for 8849 (Unihertz) Tank Mini

### DIFF
--- a/8849/Tank_Mini/Android.mk
+++ b/8849/Tank_Mini/Android.mk
@@ -1,0 +1,8 @@
+LOCAL_PATH := $(call my-dir)
+include $(CLEAR_VARS)
+LOCAL_MODULE_TAGS := optional
+LOCAL_PACKAGE_NAME := treble-overlay-8849-tank-mini
+LOCAL_MODULE_PATH := $(TARGET_OUT_PRODUCT)/overlay
+LOCAL_IS_RUNTIME_RESOURCE_OVERLAY := true
+LOCAL_PRIVATE_PLATFORM_APIS := true
+include $(BUILD_PACKAGE)

--- a/8849/Tank_Mini/AndroidManifest.xml
+++ b/8849/Tank_Mini/AndroidManifest.xml
@@ -1,0 +1,10 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+        package="me.phh.treble.overlay.eight_eight_four_nine.tank_mini"
+        android:versionCode="1"
+        android:versionName="1.0">
+        <overlay android:targetPackage="android"
+                android:requiredSystemPropertyName="ro.vendor.build.fingerprint"
+                android:requiredSystemPropertyValue="+8849/TANK_MINI_1*"
+		android:priority="8849"
+		android:isStatic="true" />
+</manifest>

--- a/8849/Tank_Mini/res/values/config.xml
+++ b/8849/Tank_Mini/res/values/config.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="config_mainBuiltInDisplayCutout">M 0,0 L -30, 0 L -30, 37 L 30, 37 L 30, 0 Z @dp</string>
+
+    <dimen name="status_bar_height_portrait">60px</dimen>
+    <dimen name="status_bar_icon_size">15dp</dimen>
+    <dimen name="status_bar_icon_size_sp">15sp</dimen>
+    <item type="dimen" name="config_screenBrightnessSettingDefaultFloat">0.35</item>
+    <item type="dimen" name="config_screenBrightnessSettingMaximumFloat">1.0</item>
+    <item type="dimen" name="config_screenBrightnessSettingMinimumFloat">0.0</item>
+
+    <integer name="config_screenBrightnessDoze">5</integer>
+
+    <bool name="config_useDevInputEventForAudioJack">true</bool>
+    <bool name="config_showNavigationBar">true</bool>
+    <bool name="config_automatic_brightness_available">true</bool>
+    <bool name="config_fillMainBuiltInDisplayCutout">false</bool>
+
+    <integer-array name="config_autoBrightnessLcdBacklightValues">
+        <item>8</item>
+        <item>64</item>
+        <item>98</item>
+        <item>104</item>
+        <item>110</item>
+        <item>116</item>
+        <item>122</item>
+        <item>128</item>
+        <item>134</item>
+        <item>182</item>
+        <item>255</item>
+        <item>255</item>
+        <item>255</item>
+        <item>255</item>
+        <item>255</item>
+        <item>255</item>
+        <item>255</item>
+        <item>255</item>
+    </integer-array>
+    <integer-array name="config_autoBrightnessLevels">
+        <item>128</item>
+        <item>256</item>
+        <item>384</item>
+        <item>512</item>
+        <item>640</item>
+        <item>768</item>
+        <item>896</item>
+        <item>1024</item>
+        <item>2048</item>
+        <item>4096</item>
+        <item>6144</item>
+        <item>8192</item>
+        <item>10240</item>
+        <item>12288</item>
+        <item>14336</item>
+        <item>16384</item>
+        <item>18432</item>
+    </integer-array>
+</resources>

--- a/8849/Tank_Mini/res/xml/power_profile.xml
+++ b/8849/Tank_Mini/res/xml/power_profile.xml
@@ -1,0 +1,246 @@
+<?xml version="1.0" encoding="utf-8"?>
+<device name="Android">
+    <item name="ambient.on">0.1</item>
+    <item name="screen.on">67.6</item>
+    <item name="screen.full">159.5</item>
+    <item name="bluetooth.active">20.7</item>
+    <item name="bluetooth.on">0.82</item>
+    <item name="wifi.on">0.07</item>
+    <item name="wifi.active">127.5</item>
+    <item name="wifi.scan">27</item>
+    <item name="audio">35.6</item>
+    <item name="video">49</item>
+    <item name="camera.flashlight">48</item>
+    <item name="camera.avg">732</item>
+    <item name="gps.on">28</item>
+    <item name="radio.active">110</item>
+    <item name="radio.scanning">6.1</item>
+    <array name="radio.on">
+        <value>6.1</value>
+        <value>6.1</value>
+    </array>
+    <array name="cpu.clusters.cores">
+        <value>6</value>
+        <value>2</value>
+    </array>
+    <array name="cpu.speeds.cluster0">
+        <value>500000</value>
+        <value>650000</value>
+        <value>700000</value>
+        <value>750000</value>
+        <value>800000</value>
+        <value>850000</value>
+        <value>900000</value>
+        <value>950000</value>
+        <value>1000000</value>
+        <value>1050000</value>
+        <value>1100000</value>
+        <value>1150000</value>
+        <value>1200000</value>
+        <value>1250000</value>
+        <value>1300000</value>
+        <value>1350000</value>
+        <value>1400000</value>
+        <value>1450000</value>
+        <value>1500000</value>
+        <value>1600000</value>
+        <value>1700000</value>
+        <value>1800000</value>
+        <value>1900000</value>
+        <value>2000000</value>
+    </array>
+    <array name="cpu.active.cluster0">
+        <value>10.6</value>
+        <value>11.4</value>
+        <value>12.4</value>
+        <value>13.2</value>
+        <value>14.0</value>
+        <value>14.2</value>
+        <value>15.2</value>
+        <value>16.2</value>
+        <value>17.4</value>
+        <value>18.4</value>
+        <value>19.8</value>
+        <value>21.2</value>
+        <value>22.6</value>
+        <value>23.4</value>
+        <value>25.0</value>
+        <value>26.8</value>
+        <value>27.8</value>
+        <value>30.0</value>
+        <value>31.6</value>
+        <value>35.8</value>
+        <value>40.0</value>
+        <value>44.2</value>
+        <value>49.0</value>
+        <value>54.4</value>
+    </array>
+    <array name="cpu.speeds.cluster1">
+        <value>725000</value>
+        <value>800000</value>
+        <value>900000</value>
+        <value>1000000</value>
+        <value>1100000</value>
+        <value>1200000</value>
+        <value>1300000</value>
+        <value>1400000</value>
+        <value>1500000</value>
+        <value>1600000</value>
+        <value>1700000</value>
+        <value>1800000</value>
+        <value>1900000</value>
+        <value>2000000</value>
+        <value>2100000</value>
+        <value>2200000</value>
+    </array>
+    <array name="cpu.active.cluster1">
+        <value>44</value>
+        <value>48</value>
+        <value>54</value>
+        <value>62</value>
+        <value>71</value>
+        <value>82</value>
+        <value>93</value>
+        <value>102</value>
+        <value>118</value>
+        <value>131</value>
+        <value>142</value>
+        <value>159</value>
+        <value>185</value>
+        <value>196</value>
+        <value>221</value>
+        <value>240</value>
+    </array>
+    <item name="cpu.idle">7.0</item>
+    <item name="cpu.suspend">5</item>
+    <item name="cpu.active">2.55</item>. <item name="cpu.cluster_power.cluster0">2.11</item>
+    <item name="cpu.cluster_power.cluster1">2.22</item>
+    <array name="cpu.core_speeds.cluster0">
+        <value>500000</value>
+        <value>650000</value>
+        <value>700000</value>
+        <value>750000</value>
+        <value>800000</value>
+        <value>850000</value>
+        <value>900000</value>
+        <value>950000</value>
+        <value>1000000</value>
+        <value>1050000</value>
+        <value>1100000</value>
+        <value>1150000</value>
+        <value>1200000</value>
+        <value>1250000</value>
+        <value>1300000</value>
+        <value>1350000</value>
+        <value>1400000</value>
+        <value>1450000</value>
+        <value>1500000</value>
+        <value>1600000</value>
+        <value>1700000</value>
+        <value>1800000</value>
+        <value>1900000</value>
+        <value>2000000</value>
+    </array>
+    <array name="cpu.core_speeds.cluster1">
+        <value>725000</value>
+        <value>800000</value>
+        <value>900000</value>
+        <value>1000000</value>
+        <value>1100000</value>
+        <value>1200000</value>
+        <value>1300000</value>
+        <value>1400000</value>
+        <value>1500000</value>
+        <value>1600000</value>
+        <value>1700000</value>
+        <value>1800000</value>
+        <value>1900000</value>
+        <value>2000000</value>
+        <value>2100000</value>
+        <value>2200000</value>
+    </array>
+    <array name="cpu.core_power.cluster0">
+        <value>10.6</value>
+        <value>11.4</value>
+        <value>12.4</value>
+        <value>13.2</value>
+        <value>14.0</value>
+        <value>14.2</value>
+        <value>15.2</value>
+        <value>16.2</value>
+        <value>17.4</value>
+        <value>18.4</value>
+        <value>19.8</value>
+        <value>21.2</value>
+        <value>22.6</value>
+        <value>23.4</value>
+        <value>25.0</value>
+        <value>26.8</value>
+        <value>27.8</value>
+        <value>30.0</value>
+        <value>31.6</value>
+        <value>35.8</value>
+        <value>40.0</value>
+        <value>44.2</value>
+        <value>49.0</value>
+        <value>54.4</value>
+    </array>
+    <array name="cpu.core_power.cluster1">
+        <value>44</value>
+        <value>48</value>
+        <value>54</value>
+        <value>62</value>
+        <value>71</value>
+        <value>82</value>
+        <value>93</value>
+        <value>102</value>
+        <value>118</value>
+        <value>131</value>
+        <value>142</value>
+        <value>159</value>
+        <value>185</value>
+        <value>196</value>
+        <value>221</value>
+        <value>240</value>
+    </array>
+    <array name="memory.bandwidths">
+        <value>22.7</value>
+    </array>
+    <item name="battery.capacity">5800</item>
+    <item name="wifi.controller.idle">0</item>
+    <item name="wifi.controller.rx">0</item>
+    <item name="wifi.controller.tx">0</item>
+    <array name="wifi.controller.tx_levels" />
+    <item name="wifi.controller.voltage">3.3</item>
+    <array name="wifi.batchedscan">
+        <value>.0002</value>
+        <value>.002</value>
+        <value>.02</value>
+        <value>.2</value>
+        <value>2</value>
+    </array>
+    <item name="modem.controller.sleep">0</item>
+    <item name="modem.controller.idle">0</item>
+    <item name="modem.controller.rx">0</item>
+    <array name="modem.controller.tx">
+        <value>0</value>
+        <value>0</value>
+        <value>0</value>
+        <value>0</value>
+        <value>0</value>
+    </array>
+    <item name="modem.controller.voltage">0</item>
+    <array name="gps.signalqualitybased">
+        <value>0</value>
+        <value>0</value>
+    </array>
+    <item name="gps.voltage">0</item>
+    <array name="custom.campinglamp.on">
+        <value>1734</value>
+        <value>888</value>
+        <value>458</value>
+        <value>721</value>
+        <value>880</value>
+    </array>
+    <item name="custom.warning_lights.on">44</item>
+</device>

--- a/overlay.mk
+++ b/overlay.mk
@@ -2,6 +2,7 @@ PRODUCT_PACKAGES += \
 	HardwareOverlayPicker \
 	QtiAudio \
 	TrebleApp \
+	treble-overlay-8849-tank-mini \
 	treble-overlay-Hisense-HLTE556N \
 	treble-overlay-NavBar \
 	treble-overlay-NightMode \


### PR DESCRIPTION
I am not sure if the Unihertz Tank Mini will use the same model / fingerprint string, but what I have is the 8849-branded version, so this is what it is.

If the Unihertz one is different maybe we can change the fingerprint regex later.