### PR TITLE
Check device's codename instead of the device's fingerprint for Infinix devices

### DIFF
--- a/Infinix/Note10/AndroidManifest.xml
+++ b/Infinix/Note10/AndroidManifest.xml
@@ -3,8 +3,8 @@
         android:versionCode="1"
         android:versionName="1.0">
         <overlay android:targetPackage="android"
-                android:requiredSystemPropertyName="ro.vendor.build.fingerprint"
-                android:requiredSystemPropertyValue="+Infinix/X693-GL/Infinix-X693*"
-        android:priority="932"
-        android:isStatic="true" />
+                android:requiredSystemPropertyName="ro.product.vendor.device"
+                android:requiredSystemPropertyValue="Infinix-X693"
+                android:priority="932"
+                android:isStatic="true" />
 </manifest>

--- a/Infinix/Note10Pro/AndroidManifest.xml
+++ b/Infinix/Note10Pro/AndroidManifest.xml
@@ -3,8 +3,8 @@
         android:versionCode="1"
         android:versionName="1.0">
         <overlay android:targetPackage="android"
-                android:requiredSystemPropertyName="ro.vendor.build.fingerprint"
-                android:requiredSystemPropertyValue="+Infinix/X695*/Infinix-X695*"
-        android:priority="547"
-        android:isStatic="true" />
+                android:requiredSystemPropertyName="ro.product.vendor.device"
+                android:requiredSystemPropertyValue="Infinix-X695"
+                android:priority="547"
+                android:isStatic="true" />
 </manifest>

--- a/Infinix/Note12v2023-SystemUI/AndroidManifest.xml
+++ b/Infinix/Note12v2023-SystemUI/AndroidManifest.xml
@@ -3,8 +3,8 @@
         android:versionCode="1"
         android:versionName="1.0">
         <overlay android:targetPackage="com.android.systemui"
-                android:requiredSystemPropertyName="ro.vendor.build.fingerprint"
-                android:requiredSystemPropertyValue="+Infinix/X676C*/Infinix-X676C*"
-        android:priority="954"
-        android:isStatic="true" />
+                android:requiredSystemPropertyName="ro.product.vendor.device"
+                android:requiredSystemPropertyValue="Infinix-X676C"
+                android:priority="954"
+                android:isStatic="true" />
 </manifest>

--- a/Infinix/Note12v2023/AndroidManifest.xml
+++ b/Infinix/Note12v2023/AndroidManifest.xml
@@ -3,8 +3,8 @@
         android:versionCode="1"
         android:versionName="1.0">
         <overlay android:targetPackage="android"
-                android:requiredSystemPropertyName="ro.vendor.build.fingerprint"
-                android:requiredSystemPropertyValue="+Infinix/X676C*/Infinix-X676C*"
-        android:priority="771"
-        android:isStatic="true" />
+                android:requiredSystemPropertyName="ro.product.vendor.device"
+                android:requiredSystemPropertyValue="Infinix-X676C"
+                android:priority="771"
+                android:isStatic="true" />
 </manifest>

--- a/Infinix/Note30-SystemUI/AndroidManifest.xml
+++ b/Infinix/Note30-SystemUI/AndroidManifest.xml
@@ -3,8 +3,8 @@
         android:versionCode="1"
         android:versionName="1.0">
         <overlay android:targetPackage="com.android.systemui"
-                android:requiredSystemPropertyName="ro.vendor.build.fingerprint"
-                android:requiredSystemPropertyValue="+Infinix/X6833B*/Infinix-X6833B*"
-        android:priority="984"
-        android:isStatic="true" />
+                android:requiredSystemPropertyName="ro.product.vendor.device"
+                android:requiredSystemPropertyValue="Infinix-X6833B"
+                android:priority="984"
+                android:isStatic="true" />
 </manifest>

--- a/Infinix/Note30/AndroidManifest.xml
+++ b/Infinix/Note30/AndroidManifest.xml
@@ -3,8 +3,8 @@
         android:versionCode="1"
         android:versionName="1.0">
         <overlay android:targetPackage="android"
-                android:requiredSystemPropertyName="ro.vendor.build.fingerprint"
-                android:requiredSystemPropertyValue="+Infinix/X6833B*/Infinix-X6833B*"
-        android:priority="304"
-        android:isStatic="true" />
+                android:requiredSystemPropertyName="ro.product.vendor.device"
+                android:requiredSystemPropertyValue="Infinix-X6833B"
+                android:priority="304"
+                android:isStatic="true" />
 </manifest>

--- a/Infinix/Note30Pro-SystemUI/AndroidManifest.xml
+++ b/Infinix/Note30Pro-SystemUI/AndroidManifest.xml
@@ -3,8 +3,8 @@
         android:versionCode="1"
         android:versionName="1.0">
         <overlay android:targetPackage="com.android.systemui"
-                android:requiredSystemPropertyName="ro.vendor.build.fingerprint"
-                android:requiredSystemPropertyValue="+Infinix/X678B*/Infinix-X678B*"
-        android:priority="983"
-        android:isStatic="true" />
+                android:requiredSystemPropertyName="ro.product.vendor.device"
+                android:requiredSystemPropertyValue="Infinix-X678B"
+                android:priority="983"
+                android:isStatic="true" />
 </manifest>

--- a/Infinix/Note30Pro/AndroidManifest.xml
+++ b/Infinix/Note30Pro/AndroidManifest.xml
@@ -3,8 +3,8 @@
         android:versionCode="1"
         android:versionName="1.0">
         <overlay android:targetPackage="android"
-                android:requiredSystemPropertyName="ro.vendor.build.fingerprint"
-                android:requiredSystemPropertyValue="+Infinix/X678B*/Infinix-X678B*"
-        android:priority="346"
-        android:isStatic="true" />
+                android:requiredSystemPropertyName="ro.product.vendor.device"
+                android:requiredSystemPropertyValue="Infinix-X678B"
+                android:priority="346"
+                android:isStatic="true" />
 </manifest>

--- a/Infinix/Note5/AndroidManifest.xml
+++ b/Infinix/Note5/AndroidManifest.xml
@@ -3,8 +3,8 @@
         android:versionCode="1"
         android:versionName="1.0">
         <overlay android:targetPackage="android"
-                android:requiredSystemPropertyName="ro.vendor.build.fingerprint"
-		android:requiredSystemPropertyValue="+Infinix/H633/Infinix-X604_sprout*"
-		android:priority="110"
-		android:isStatic="true" />
+                android:requiredSystemPropertyName="ro.product.vendor.device"
+                android:requiredSystemPropertyValue="Infinix-X604_sprout"
+                android:priority="110"
+                android:isStatic="true" />
 </manifest>

--- a/Infinix/Note7/AndroidManifest.xml
+++ b/Infinix/Note7/AndroidManifest.xml
@@ -3,8 +3,8 @@
         android:versionCode="1"
         android:versionName="1.0">
         <overlay android:targetPackage="android"
-                android:requiredSystemPropertyName="ro.vendor.build.fingerprint"
-		android:requiredSystemPropertyValue="+Infinix/X690B-GL/Infinix-X690B*"
-		android:priority="115"
-		android:isStatic="true" />
+                android:requiredSystemPropertyName="ro.product.vendor.device"
+                android:requiredSystemPropertyValue="Infinix-X690B"
+                android:priority="115"
+                android:isStatic="true" />
 </manifest>

--- a/Infinix/Note8/AndroidManifest.xml
+++ b/Infinix/Note8/AndroidManifest.xml
@@ -3,8 +3,8 @@
         android:versionCode="1"
         android:versionName="1.0">
         <overlay android:targetPackage="android"
-                android:requiredSystemPropertyName="ro.vendor.build.fingerprint"
-		android:requiredSystemPropertyValue="+Infinix/X692-GL/Infinix-X692*"
-		android:priority="116"
-		android:isStatic="true" />
+                android:requiredSystemPropertyName="ro.product.vendor.device"
+                android:requiredSystemPropertyValue="Infinix-X692"
+                android:priority="116"
+                android:isStatic="true" />
 </manifest>

--- a/Infinix/S4/AndroidManifest.xml
+++ b/Infinix/S4/AndroidManifest.xml
@@ -3,8 +3,8 @@
         android:versionCode="1"
         android:versionName="1.0">
         <overlay android:targetPackage="android"
-                android:requiredSystemPropertyName="ro.vendor.build.fingerprint"
-		android:requiredSystemPropertyValue="+Infinix/H624/Infinix-X626*"
-		android:priority="24"
-		android:isStatic="true" />
+                android:requiredSystemPropertyName="ro.product.vendor.device"
+                android:requiredSystemPropertyValue="Infinix-X626"
+                android:priority="24"
+                android:isStatic="true" />
 </manifest>

--- a/Infinix/Zero6/AndroidManifest.xml
+++ b/Infinix/Zero6/AndroidManifest.xml
@@ -3,8 +3,8 @@
         android:versionCode="1"
         android:versionName="1.0">
         <overlay android:targetPackage="android"
-                android:requiredSystemPropertyName="ro.vendor.build.fingerprint"
-                android:requiredSystemPropertyValue="+*Infinix/Q6361A/Infinix-X620*"
-		android:priority="99"
-		android:isStatic="true" />
+                android:requiredSystemPropertyName="ro.product.vendor.device"
+                android:requiredSystemPropertyValue="Infinix-X620"
+                android:priority="99"
+                android:isStatic="true" />
 </manifest>

--- a/Infinix/ZeroXPro/AndroidManifest.xml
+++ b/Infinix/ZeroXPro/AndroidManifest.xml
@@ -3,8 +3,8 @@
         android:versionCode="1"
         android:versionName="1.0">
         <overlay android:targetPackage="android"
-                android:requiredSystemPropertyName="ro.vendor.build.fingerprint"
-                android:requiredSystemPropertyValue="+Infinix/X6811*/Infinix-X6811*"
-        android:priority="447"
-        android:isStatic="true" />
+                android:requiredSystemPropertyName="ro.product.vendor.device"
+                android:requiredSystemPropertyValue="Infinix-X6811"
+                android:priority="447"
+                android:isStatic="true" />
 </manifest>


### PR DESCRIPTION
Some TD-based ROMs have no support for wildcards for android:requiredSystemPropertyValue, so just check for ro.product.vendor.device since we don't need to use wildcards here.

Additionally this will make overlays work on non global region Infinix firmwares for some overlays that specifically check global region device's fingerprint.