### PR TITLE
Define more codenames for some Infinix device models

### DIFF
--- a/Infinix/Note10Pro/AndroidManifest.xml
+++ b/Infinix/Note10Pro/AndroidManifest.xml
@@ -4,7 +4,7 @@
         android:versionName="1.0">
         <overlay android:targetPackage="android"
                 android:requiredSystemPropertyName="ro.product.vendor.device"
-                android:requiredSystemPropertyValue="Infinix-X695"
+                android:requiredSystemPropertyValue="+(Infinix-X695|Infinix-X695D)"
                 android:priority="547"
                 android:isStatic="true" />
 </manifest>

--- a/Infinix/Note30-SystemUI/AndroidManifest.xml
+++ b/Infinix/Note30-SystemUI/AndroidManifest.xml
@@ -4,7 +4,7 @@
         android:versionName="1.0">
         <overlay android:targetPackage="com.android.systemui"
                 android:requiredSystemPropertyName="ro.product.vendor.device"
-                android:requiredSystemPropertyValue="Infinix-X6833B"
+                android:requiredSystemPropertyValue="+(Infinix-X6833B|Infinix-X6716B)"
                 android:priority="984"
                 android:isStatic="true" />
 </manifest>

--- a/Infinix/Note30/AndroidManifest.xml
+++ b/Infinix/Note30/AndroidManifest.xml
@@ -4,7 +4,7 @@
         android:versionName="1.0">
         <overlay android:targetPackage="android"
                 android:requiredSystemPropertyName="ro.product.vendor.device"
-                android:requiredSystemPropertyValue="Infinix-X6833B"
+                android:requiredSystemPropertyValue="+(Infinix-X6833B|Infinix-X6716B)"
                 android:priority="304"
                 android:isStatic="true" />
 </manifest>

--- a/Infinix/Note5/AndroidManifest.xml
+++ b/Infinix/Note5/AndroidManifest.xml
@@ -3,8 +3,8 @@
         android:versionCode="1"
         android:versionName="1.0">
         <overlay android:targetPackage="android"
-                android:requiredSystemPropertyName="ro.product.vendor.device"
-                android:requiredSystemPropertyValue="Infinix-X604_sprout"
+                android:requiredSystemPropertyName="ro.vendor.build.fingerprint"
+                android:requiredSystemPropertyValue="+(Infinix/*/Infinix-X604*|Infinix/*/Infinix-X605*)"
                 android:priority="110"
                 android:isStatic="true" />
 </manifest>

--- a/Infinix/Note7/AndroidManifest.xml
+++ b/Infinix/Note7/AndroidManifest.xml
@@ -4,7 +4,7 @@
         android:versionName="1.0">
         <overlay android:targetPackage="android"
                 android:requiredSystemPropertyName="ro.product.vendor.device"
-                android:requiredSystemPropertyValue="Infinix-X690B"
+                android:requiredSystemPropertyValue="+(Infinix-X656|Infinix-X690|Infinix-X690B)"
                 android:priority="115"
                 android:isStatic="true" />
 </manifest>

--- a/Infinix/S4/AndroidManifest.xml
+++ b/Infinix/S4/AndroidManifest.xml
@@ -4,7 +4,7 @@
         android:versionName="1.0">
         <overlay android:targetPackage="android"
                 android:requiredSystemPropertyName="ro.product.vendor.device"
-                android:requiredSystemPropertyValue="Infinix-X626"
+                android:requiredSystemPropertyValue="+(Infinix-X626*|Infinix-X610B)"
                 android:priority="24"
                 android:isStatic="true" />
 </manifest>

--- a/Infinix/Zero6/AndroidManifest.xml
+++ b/Infinix/Zero6/AndroidManifest.xml
@@ -3,8 +3,8 @@
         android:versionCode="1"
         android:versionName="1.0">
         <overlay android:targetPackage="android"
-                android:requiredSystemPropertyName="ro.product.vendor.device"
-                android:requiredSystemPropertyValue="Infinix-X620"
+                android:requiredSystemPropertyName="ro.vendor.build.fingerprint"
+                android:requiredSystemPropertyValue="+Infinix/*/Infinix-X620*"
                 android:priority="99"
                 android:isStatic="true" />
 </manifest>

--- a/Infinix/ZeroXPro/AndroidManifest.xml
+++ b/Infinix/ZeroXPro/AndroidManifest.xml
@@ -4,7 +4,7 @@
         android:versionName="1.0">
         <overlay android:targetPackage="android"
                 android:requiredSystemPropertyName="ro.product.vendor.device"
-                android:requiredSystemPropertyValue="Infinix-X6811"
+                android:requiredSystemPropertyValue="+(Infinix-X6810|Infinix-X6811*)"
                 android:priority="447"
                 android:isStatic="true" />
 </manifest>


### PR DESCRIPTION
Infinix released multiple devices with different codenames under the same model, possibly devices for specific types of regions. They basically has the same exact specs, so we should just include all of them.
I redid the PR because I thought the last one was badly done lol, don't really want to clutter the commit history. It should also pass the build checks now.