### PR TITLE
Added Overlay for Samsung Tab A8

### DIFF
--- a/Samsung/gta8wifi/Android.mk
+++ b/Samsung/gta8wifi/Android.mk
@@ -1,0 +1,8 @@
+LOCAL_PATH := $(call my-dir)
+include $(CLEAR_VARS)
+LOCAL_MODULE_TAGS := optional
+LOCAL_PACKAGE_NAME := treble-overlay-samsung-gta8wifi
+LOCAL_MODULE_PATH := $(TARGET_OUT_PRODUCT)/overlay
+LOCAL_IS_RUNTIME_RESOURCE_OVERLAY := true
+LOCAL_PRIVATE_PLATFORM_APIS := true
+include $(BUILD_PACKAGE)

--- a/Samsung/gta8wifi/AndroidManifest.xml
+++ b/Samsung/gta8wifi/AndroidManifest.xml
@@ -1,0 +1,10 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+        package="me.phh.treble.overlay.samsung.gta8wifi"
+        android:versionCode="1"
+        android:versionName="1.0">
+        <overlay android:targetPackage="android"
+        	android:requiredSystemPropertyName="ro.vendor.build.fingerprint"
+        	android:requiredSystemPropertyValue="+*samsung/gta8wifi*"
+		android:priority="512"
+		android:isStatic="true" />
+</manifest>

--- a/Samsung/gta8wifi/res/values/config.xml
+++ b/Samsung/gta8wifi/res/values/config.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="config_supportAudioSourceUnprocessed">false</bool>
+</resources>


### PR DESCRIPTION
Added files for tab a8. I found vendor has all 5 files i need (arrays, bools, dimens, integers, strings) but product has only two (bools and strings). So i took the two and compared and did everything well.

Is this correct or should i have done it differently?

Am following this guide:

https://github.com/phhusson/treble_experimentations/wiki/How-to-create-an-overlay%3F#comparing-the-product-and-vendor-overlays


Other than that everything else is fine.