### PR TITLE
Suppress crashes of com.android.phone on Y700 2023

### DIFF
--- a/Lenovo/Y700-2023/res/values/config.xml
+++ b/Lenovo/Y700-2023/res/values/config.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <bool name="config_voice_capable">false</bool>
+    <bool name="config_sms_capable">false</bool>
+    <bool name="config_mobile_data_capable">false</bool>
+
     <bool name="config_useDevInputEventForAudioJack">true</bool>
     <bool name="config_showNavigationBar">true</bool>
     <bool name="config_automatic_brightness_available">true</bool>


### PR DESCRIPTION
The com.android.phone process keeps crashing on Y700 2023 (TB320FC). Because Y700 has no modem, accessing to modem HAL causes crashes.
This patch resolve the issue by declaring as no modem in config.xml.

RIL.java calms down by detecting the config in the folllowing lines.
https://cs.android.com/android/platform/superproject/main/+/main:frameworks/opt/telephony/src/java/com/android/internal/telephony/RIL.java;drc=4122fdd2da8280debaa61ec2852513da1f0bc9ac;l=1147
https://cs.android.com/android/platform/superproject/main/+/main:frameworks/opt/telephony/src/java/com/android/internal/telephony/RIL.java;drc=4122fdd2da8280debaa61ec2852513da1f0bc9ac;l=709