### PR TITLE
Add overlay for Redmi Note 13 5G (gold)

### DIFF
--- a/Xiaomi/RedmiNote135G/Android.mk
+++ b/Xiaomi/RedmiNote135G/Android.mk
@@ -1,0 +1,8 @@
+LOCAL_PATH := $(call my-dir)
+include $(CLEAR_VARS)
+LOCAL_MODULE_TAGS := optional
+LOCAL_PACKAGE_NAME := treble-overlay-xiaomi-redminote135g
+LOCAL_MODULE_PATH := $(TARGET_OUT_PRODUCT)/overlay
+LOCAL_IS_RUNTIME_RESOURCE_OVERLAY := true
+LOCAL_PRIVATE_PLATFORM_APIS := true
+include $(BUILD_PACKAGE)

--- a/Xiaomi/RedmiNote135G/AndroidManifest.xml
+++ b/Xiaomi/RedmiNote135G/AndroidManifest.xml
@@ -3,8 +3,8 @@
         android:versionCode="1"
         android:versionName="1.0">
         <overlay android:targetPackage="android"
-        	android:requiredSystemPropertyName="ro.vendor.build.fingerprint"
-        	android:requiredSystemPropertyValue="+*Redmi/gold*"
+        	android:requiredSystemPropertyName="ro.product.vendor.device"
+                android:requiredSystemPropertyValue="+(gold|iron)"
 		android:priority="666"
 		android:isStatic="true" />
 </manifest>

--- a/Xiaomi/RedmiNote135G/AndroidManifest.xml
+++ b/Xiaomi/RedmiNote135G/AndroidManifest.xml
@@ -1,0 +1,10 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+        package="me.phh.treble.overlay.xiaomi.redminote135g"
+        android:versionCode="1"
+        android:versionName="1.0">
+        <overlay android:targetPackage="android"
+        	android:requiredSystemPropertyName="ro.vendor.build.fingerprint"
+        	android:requiredSystemPropertyValue="+*Redmi/gold*"
+		android:priority="666"
+		android:isStatic="true" />
+</manifest>

--- a/Xiaomi/RedmiNote135G/res/values/config.xml
+++ b/Xiaomi/RedmiNote135G/res/values/config.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="config_mainBuiltInDisplayCutout">M 0,0 H -28 V 94 H 28 V 0 H 0 Z</string>
+    <dimen name="rounded_corner_radius">70px</dimen>
+    <dimen name="rounded_corner_radius_bottom">70px</dimen>
+    <dimen name="rounded_corner_radius_top">70px</dimen>
+    <dimen name="status_bar_height_default">94px</dimen>
+    <dimen name="status_bar_height_portrait">94px</dimen>
+    
+    <integer name="config_autoBrightnessBrighteningLightDebounce">1000</integer>
+    <integer name="config_autoBrightnessDarkeningLightDebounce">1000</integer>
+    <integer name="config_brightness_ramp_rate_fast">2466</integer>
+    <integer name="config_brightness_ramp_rate_slow">1973</integer>
+    <integer name="config_defaultPeakRefreshRate">120</integer>
+    <integer name="config_screenBrightnessDim">8</integer>
+    <integer name="config_screenBrightnessSettingDefault">307</integer>
+    <integer name="config_screenBrightnessSettingMaximum">4095</integer>
+    <integer name="config_screenBrightnessSettingMinimum">8</integer>
+    <integer name="config_shutdownBatteryTemperature">600</integer>
+    
+    <fraction name="config_autoBrightnessAdjustmentMaxGamma">100%</fraction>
+    
+    <bool name="config_displayBlanksAfterDoze">false</bool>
+    <bool name="config_powerDecoupleAutoSuspendModeFromDisplay">true</bool>
+    <bool name="config_showNavigationBar">true</bool>
+    <bool name="config_wifi_connected_mac_randomization_supported">true</bool>
+    <bool name="config_carrier_volte_available">true</bool>
+    <bool name="config_device_volte_available">true</bool>
+    <bool name="config_carrier_wfc_ims_available">true</bool>
+    <bool name="config_device_wfc_ims_available">true</bool>
+    <bool name="config_device_vt_available">true</bool>
+    <bool name="config_carrier_volte_provisioned">true</bool>
+    <bool name="config_carrier_volte_tty_supported">false</bool>
+    <bool name="config_carrier_vt_available">true</bool>
+</resources>

--- a/Xiaomi/RedmiNote135G/res/values/config.xml
+++ b/Xiaomi/RedmiNote135G/res/values/config.xml
@@ -1,35 +1,408 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-    <string name="config_mainBuiltInDisplayCutout">M 0,0 H -28 V 94 H 28 V 0 H 0 Z</string>
+    <array name="config_ambientBrighteningThresholds">
+        <item>7</item>
+        <item>10</item>
+        <item>10</item>
+        <item>30</item>
+        <item>100</item>
+        <item>400</item>
+        <item>600</item>
+        <item>1000</item>
+    </array>
+    <array name="config_ambientDarkeningThresholds">
+        <item>900</item>
+        <item>900</item>
+        <item>500</item>
+        <item>500</item>
+        <item>500</item>
+        <item>500</item>
+        <item>500</item>
+        <item>500</item>
+    </array>
+    <array name="config_ambientThresholdLevels">
+        <item>2</item>
+        <item>10</item>
+        <item>30</item>
+        <item>100</item>
+        <item>800</item>
+        <item>2000</item>
+        <item>4000</item>
+    </array>
+    <array name="config_autoBrightnessDisplayValuesNits">
+        <item>4.2</item>
+        <item>5</item>
+        <item>5.8</item>
+        <item>19.5</item>
+        <item>26</item>
+        <item>34.1</item>
+        <item>37.4</item>
+        <item>48.4</item>
+        <item>62.7</item>
+        <item>81.4</item>
+        <item>89.1</item>
+        <item>90.2</item>
+        <item>90.2</item>
+        <item>90.2</item>
+        <item>91.3</item>
+        <item>91.3</item>
+        <item>91.3</item>
+        <item>92.4</item>
+        <item>92.4</item>
+        <item>93.5</item>
+        <item>93.5</item>
+        <item>93.5</item>
+        <item>93.5</item>
+        <item>94.6</item>
+        <item>94.6</item>
+        <item>95.7</item>
+        <item>97.9</item>
+        <item>99</item>
+        <item>100.1</item>
+        <item>102.3</item>
+        <item>103.4</item>
+        <item>105.6</item>
+        <item>106.7</item>
+        <item>108.9</item>
+        <item>115</item>
+        <item>116.1</item>
+        <item>119.4</item>
+        <item>120.5</item>
+        <item>121.6</item>
+        <item>123.8</item>
+        <item>124.9</item>
+        <item>127.1</item>
+        <item>128.2</item>
+        <item>130.4</item>
+        <item>132.6</item>
+        <item>155.7</item>
+        <item>177.7</item>
+        <item>199.7</item>
+        <item>230.5</item>
+        <item>253.6</item>
+        <item>287.7</item>
+        <item>313</item>
+        <item>329.5</item>
+        <item>405.9</item>
+        <item>440</item>
+        <item>458.4</item>
+        <item>476.6</item>
+        <item>489.5</item>
+        <item>490</item>
+        <item>495</item>
+        <item>500</item>
+        <item>512.5</item>
+        <item>525</item>
+        <item>537.5</item>
+        <item>550</item>
+        <item>562.5</item>
+        <item>575</item>
+        <item>587.5</item>
+        <item>600</item>
+        <item>610</item>
+        <item>620</item>
+        <item>630</item>
+        <item>640</item>
+        <item>650</item>
+        <item>660</item>
+        <item>670</item>
+        <item>680</item>
+        <item>690</item>
+        <item>700</item>
+        <item>705</item>
+        <item>710</item>
+        <item>715</item>
+        <item>720</item>
+        <item>725</item>
+        <item>730</item>
+        <item>735</item>
+        <item>740</item>
+        <item>745</item>
+        <item>750</item>
+        <item>755</item>
+        <item>760</item>
+        <item>765</item>
+        <item>770</item>
+        <item>775</item>
+        <item>800</item>
+        <item>816.7</item>
+        <item>833.3</item>
+        <item>850</item>
+        <item>866.7</item>
+        <item>883.3</item>
+        <item>900</item>
+        <item>914.3</item>
+        <item>928.6</item>
+        <item>942.9</item>
+        <item>957.1</item>
+        <item>971.4</item>
+        <item>985.7</item>
+        <item>1000</item>
+    </array>
+    <array name="config_autoBrightnessLcdBacklightValues">
+        <item>14</item>
+        <item>17</item>
+        <item>20</item>
+        <item>69</item>
+        <item>94</item>
+        <item>126</item>
+        <item>139</item>
+        <item>180</item>
+        <item>233</item>
+        <item>302</item>
+        <item>331</item>
+        <item>335</item>
+        <item>335</item>
+        <item>335</item>
+        <item>339</item>
+        <item>339</item>
+        <item>339</item>
+        <item>343</item>
+        <item>343</item>
+        <item>347</item>
+        <item>347</item>
+        <item>347</item>
+        <item>347</item>
+        <item>352</item>
+        <item>352</item>
+        <item>356</item>
+        <item>364</item>
+        <item>368</item>
+        <item>372</item>
+        <item>380</item>
+        <item>384</item>
+        <item>393</item>
+        <item>397</item>
+        <item>405</item>
+        <item>409</item>
+        <item>413</item>
+        <item>425</item>
+        <item>429</item>
+        <item>433</item>
+        <item>442</item>
+        <item>446</item>
+        <item>454</item>
+        <item>458</item>
+        <item>466</item>
+        <item>474</item>
+        <item>560</item>
+        <item>642</item>
+        <item>724</item>
+        <item>839</item>
+        <item>925</item>
+        <item>1052</item>
+        <item>1146</item>
+        <item>1207</item>
+        <item>1510</item>
+        <item>1637</item>
+        <item>1705</item>
+        <item>1773</item>
+        <item>1821</item>
+        <item>1910</item>
+        <item>1978</item>
+        <item>2047</item>
+        <item>2098</item>
+        <item>2149</item>
+        <item>2200</item>
+        <item>2251</item>
+        <item>2302</item>
+        <item>2354</item>
+        <item>2405</item>
+        <item>2456</item>
+        <item>2497</item>
+        <item>2538</item>
+        <item>2579</item>
+        <item>2620</item>
+        <item>2661</item>
+        <item>2702</item>
+        <item>2742</item>
+        <item>2783</item>
+        <item>2824</item>
+        <item>2865</item>
+        <item>2886</item>
+        <item>2906</item>
+        <item>2927</item>
+        <item>2947</item>
+        <item>2968</item>
+        <item>2988</item>
+        <item>3009</item>
+        <item>3029</item>
+        <item>3050</item>
+        <item>3070</item>
+        <item>3090</item>
+        <item>3111</item>
+        <item>3131</item>
+        <item>3152</item>
+        <item>3172</item>
+        <item>3275</item>
+        <item>3343</item>
+        <item>3411</item>
+        <item>3479</item>
+        <item>3548</item>
+        <item>3616</item>
+        <item>3684</item>
+        <item>3743</item>
+        <item>3801</item>
+        <item>3860</item>
+        <item>3918</item>
+        <item>3976</item>
+        <item>4035</item>
+        <item>4095</item>
+    </array>
+    <array name="config_autoBrightnessLevels">
+        <item>1</item>
+        <item>2</item>
+        <item>4</item>
+        <item>6</item>
+        <item>8</item>
+        <item>10</item>
+        <item>15</item>
+        <item>20</item>
+        <item>25</item>
+        <item>30</item>
+        <item>35</item>
+        <item>40</item>
+        <item>45</item>
+        <item>50</item>
+        <item>55</item>
+        <item>60</item>
+        <item>65</item>
+        <item>70</item>
+        <item>75</item>
+        <item>80</item>
+        <item>85</item>
+        <item>90</item>
+        <item>95</item>
+        <item>100</item>
+        <item>120</item>
+        <item>140</item>
+        <item>160</item>
+        <item>180</item>
+        <item>200</item>
+        <item>220</item>
+        <item>240</item>
+        <item>260</item>
+        <item>280</item>
+        <item>300</item>
+        <item>320</item>
+        <item>340</item>
+        <item>360</item>
+        <item>380</item>
+        <item>400</item>
+        <item>420</item>
+        <item>440</item>
+        <item>460</item>
+        <item>480</item>
+        <item>500</item>
+        <item>700</item>
+        <item>900</item>
+        <item>1100</item>
+        <item>1300</item>
+        <item>1500</item>
+        <item>1700</item>
+        <item>1900</item>
+        <item>2000</item>
+        <item>2500</item>
+        <item>3000</item>
+        <item>3500</item>
+        <item>4000</item>
+        <item>4500</item>
+        <item>5000</item>
+        <item>5500</item>
+        <item>6000</item>
+        <item>6500</item>
+        <item>7000</item>
+        <item>7500</item>
+        <item>8000</item>
+        <item>8500</item>
+        <item>9000</item>
+        <item>9500</item>
+        <item>10000</item>
+        <item>10500</item>
+        <item>11000</item>
+        <item>11500</item>
+        <item>12000</item>
+        <item>12500</item>
+        <item>13000</item>
+        <item>13500</item>
+        <item>14000</item>
+        <item>14500</item>
+        <item>15000</item>
+        <item>16000</item>
+        <item>17000</item>
+        <item>18000</item>
+        <item>19000</item>
+        <item>20000</item>
+        <item>21000</item>
+        <item>22000</item>
+        <item>23000</item>
+        <item>24000</item>
+        <item>25000</item>
+        <item>26000</item>
+        <item>27000</item>
+        <item>28000</item>
+        <item>29000</item>
+        <item>30000</item>
+        <item>35000</item>
+        <item>40000</item>
+        <item>45000</item>
+        <item>50000</item>
+        <item>55000</item>
+        <item>60000</item>
+        <item>65000</item>
+        <item>70000</item>
+        <item>75000</item>
+        <item>80000</item>
+        <item>85000</item>
+        <item>90000</item>
+        <item>95000</item>
+        <item>100000</item>
+    </array>
+    <array name="config_screenBrighteningThresholds">
+        <item>@null</item>
+    </array>
+    <array name="config_screenDarkeningThresholds">
+        <item>@null</item>
+    </array>
+	
+    <bool name="config_automatic_brightness_available">true</bool>
+    <bool name="config_carrier_volte_available" value="true"/>
+    <bool name="config_carrier_wfc_ims_available" value="true"/>
+    <bool name="config_device_volte_available" value="true"/>
+    <bool name="config_device_vt_available" value="true"/>
+    <bool name="config_device_wfc_ims_available" value="true"/>
+    <bool name="config_dozeAfterScreenOff">true</bool>
+    <bool name="config_enableFusedLocationOverlay">true</bool>
+    <bool name="config_enableNetworkLocationOverlay">true</bool>
+    <bool name="config_powerDecoupleAutoSuspendModeFromDisplay">true</bool>
+    <bool name="config_powerDecoupleInteractiveModeFromDisplay">true</bool>
+    <bool name="config_showNavigationBar">true</bool>
+    <bool name="config_suspendWhenScreenOffDueToProximity">true</bool>
+    <bool name="config_wifi_background_scan_support">true</bool>
+    <bool name="config_wifi_connected_mac_randomization_supported">true</bool>
+    <bool name="config_wifi_fast_bss_transition_enabled">true</bool>
+    <bool name="config_wifi_p2p_mac_randomization_supported">true</bool>
+	
+    <dimen name="config_screenBrightnessSettingDefaultFloat">0.35</dimen>
+    <dimen name="config_screenBrightnessSettingMaximumFloat">1</dimen>
+    <dimen name="config_screenBrightnessSettingMinimumFloat">0.0039</dimen>
+    <dimen name="navigation_bar_height">16dp</dimen>
+    <dimen name="navigation_bar_height_landscape">16dp</dimen>
+    <dimen name="navigation_bar_width">24dp</dimen>
     <dimen name="rounded_corner_radius">70px</dimen>
     <dimen name="rounded_corner_radius_bottom">70px</dimen>
     <dimen name="rounded_corner_radius_top">70px</dimen>
     <dimen name="status_bar_height_default">94px</dimen>
     <dimen name="status_bar_height_portrait">94px</dimen>
-    
-    <integer name="config_autoBrightnessBrighteningLightDebounce">1000</integer>
-    <integer name="config_autoBrightnessDarkeningLightDebounce">1000</integer>
-    <integer name="config_brightness_ramp_rate_fast">2466</integer>
-    <integer name="config_brightness_ramp_rate_slow">1973</integer>
-    <integer name="config_defaultPeakRefreshRate">120</integer>
-    <integer name="config_screenBrightnessDim">8</integer>
-    <integer name="config_screenBrightnessSettingDefault">307</integer>
-    <integer name="config_screenBrightnessSettingMaximum">4095</integer>
-    <integer name="config_screenBrightnessSettingMinimum">8</integer>
-    <integer name="config_shutdownBatteryTemperature">600</integer>
-    
-    <fraction name="config_autoBrightnessAdjustmentMaxGamma">100%</fraction>
-    
-    <bool name="config_displayBlanksAfterDoze">false</bool>
-    <bool name="config_powerDecoupleAutoSuspendModeFromDisplay">true</bool>
-    <bool name="config_showNavigationBar">true</bool>
-    <bool name="config_wifi_connected_mac_randomization_supported">true</bool>
-    <bool name="config_carrier_volte_available">true</bool>
-    <bool name="config_device_volte_available">true</bool>
-    <bool name="config_carrier_wfc_ims_available">true</bool>
-    <bool name="config_device_wfc_ims_available">true</bool>
-    <bool name="config_device_vt_available">true</bool>
-    <bool name="config_carrier_volte_provisioned">true</bool>
-    <bool name="config_carrier_volte_tty_supported">false</bool>
-    <bool name="config_carrier_vt_available">true</bool>
+	
+    <integer name="config_defaultPeakRefreshRate">121</integer>
+    <integer name="config_defaultRefreshRate">121</integer>
+    <integer name="config_screenBrightnessDoze">5</integer>
+	
+    <string name="config_mainBuiltInDisplayCutout">M 0,0 H -28 V 94 H 28 V 0 H 0 Z</string>
+	<string name="config_mainBuiltInDisplayCutoutRectApproximation">M 0,0 H -28 V 94 H 28 V 0 H 0 Z</string>
+	
+    <string-array name="config_biometric_sensors">
+        <item>0:2:15</item>
+    </string-array>
 </resources>

--- a/Xiaomi/RedmiNote135G/res/values/config.xml
+++ b/Xiaomi/RedmiNote135G/res/values/config.xml
@@ -384,9 +384,6 @@
     <bool name="config_wifi_fast_bss_transition_enabled">true</bool>
     <bool name="config_wifi_p2p_mac_randomization_supported">true</bool>
 	
-    <dimen name="config_screenBrightnessSettingDefaultFloat">0.35</dimen>
-    <dimen name="config_screenBrightnessSettingMaximumFloat">1</dimen>
-    <dimen name="config_screenBrightnessSettingMinimumFloat">0.0039</dimen>
     <dimen name="navigation_bar_height">16dp</dimen>
     <dimen name="navigation_bar_height_landscape">16dp</dimen>
     <dimen name="navigation_bar_width">24dp</dimen>
@@ -412,6 +409,10 @@
     <integer name="config_defaultPeakRefreshRate">121</integer>
     <integer name="config_defaultRefreshRate">121</integer>
     <integer name="config_screenBrightnessDoze">5</integer>
+	
+    <item type="dimen" name="config_screenBrightnessSettingDefaultFloat">4</item>
+    <item type="dimen" name="config_screenBrightnessSettingMaximumFloat">1</item>
+    <item type="dimen" name="config_screenBrightnessSettingMinimumFloat">0</item>
 	
     <string name="config_mainBuiltInDisplayCutout">M 0,0 H -28 V 94 H 28 V 0 H 0 Z</string>
 	<string name="config_mainBuiltInDisplayCutoutRectApproximation">M 0,0 H -28 V 94 H 28 V 0 H 0 Z</string>

--- a/Xiaomi/RedmiNote135G/res/values/config.xml
+++ b/Xiaomi/RedmiNote135G/res/values/config.xml
@@ -366,14 +366,15 @@
     </array>
 	
     <bool name="config_automatic_brightness_available">true</bool>
-    <bool name="config_carrier_volte_available" value="true"/>
-    <bool name="config_carrier_wfc_ims_available" value="true"/>
-    <bool name="config_device_volte_available" value="true"/>
-    <bool name="config_device_vt_available" value="true"/>
-    <bool name="config_device_wfc_ims_available" value="true"/>
+    <bool name="config_carrier_volte_available">true</bool>
+    <bool name="config_carrier_wfc_ims_available">true</bool>
+    <bool name="config_device_volte_available">true</bool>
+    <bool name="config_device_vt_available">true</bool>
+    <bool name="config_device_wfc_ims_available">true</bool>
     <bool name="config_dozeAfterScreenOff">true</bool>
     <bool name="config_enableFusedLocationOverlay">true</bool>
     <bool name="config_enableNetworkLocationOverlay">true</bool>
+	<bool name="config_displayBlanksAfterDoze">false</bool>
     <bool name="config_powerDecoupleAutoSuspendModeFromDisplay">true</bool>
     <bool name="config_powerDecoupleInteractiveModeFromDisplay">true</bool>
     <bool name="config_showNavigationBar">true</bool>
@@ -395,6 +396,19 @@
     <dimen name="status_bar_height_default">94px</dimen>
     <dimen name="status_bar_height_portrait">94px</dimen>
 	
+    <!-- exp
+	<fraction name="config_autoBrightnessAdjustmentMaxGamma">100%</fraction>
+	
+	<integer name="config_autoBrightnessBrighteningLightDebounce">1000</integer>
+    <integer name="config_autoBrightnessDarkeningLightDebounce">1000</integer>
+    <integer name="config_brightness_ramp_rate_fast">2466</integer>
+    <integer name="config_brightness_ramp_rate_slow">1973</integer>
+    <integer name="config_screenBrightnessDim">8</integer>
+    <integer name="config_screenBrightnessSettingDefault">307</integer>
+    <integer name="config_screenBrightnessSettingMaximum">4095</integer>
+    <integer name="config_screenBrightnessSettingMinimum">8</integer>
+	<integer name="config_shutdownBatteryTemperature">600</integer>
+	-->
     <integer name="config_defaultPeakRefreshRate">121</integer>
     <integer name="config_defaultRefreshRate">121</integer>
     <integer name="config_screenBrightnessDoze">5</integer>

--- a/Xiaomi/RedmiNote135G/res/xml/power_profile.xml
+++ b/Xiaomi/RedmiNote135G/res/xml/power_profile.xml
@@ -1,0 +1,240 @@
+<?xml version="1.0" encoding="utf-8"?>
+<device xmlns:android="http://schemas.android.com/apk/res/android" name="Android">
+    <item name="ambient.on">0.1
+    </item>
+    <item name="screen.on">46.13
+    </item>
+    <item name="screen.full">350.08
+    </item>
+    <item name="bluetooth.active">20.91
+    </item>
+    <item name="bluetooth.on">7.43
+    </item>
+    <item name="wifi.on">7.76
+    </item>
+    <item name="wifi.active">192.96
+    </item>
+    <item name="wifi.scan">17.41
+    </item>
+    <item name="audio">28.33
+    </item>
+    <item name="video">45.21
+    </item>
+    <item name="camera.flashlight">116.2
+    </item>
+    <item name="camera.avg">483.71
+    </item>
+    <item name="gps.on">27.42
+    </item>
+    <item name="radio.active">194.13
+    </item>
+    <item name="radio.scanning">112.73
+    </item>
+    <array name="radio.on">
+        <value>4.86
+        </value>
+    </array>
+    <array name="cpu.active">
+        <value>0.1
+        </value>
+    </array>
+    <array name="cpu.clusters.cores">
+        <value>6
+        </value>
+        <value>2
+        </value>
+    </array>
+    <array name="cpu.core_speeds.cluster0">
+        <value>2000000
+        </value>
+        <value>1916000
+        </value>
+        <value>1812000
+        </value>
+        <value>1750000
+        </value>
+        <value>1645000
+        </value>
+        <value>1500000
+        </value>
+        <value>1393000
+        </value>
+        <value>1287000
+        </value>
+        <value>1128000
+        </value>
+        <value>1048000
+        </value>
+        <value>968000
+        </value>
+        <value>862000
+        </value>
+        <value>756000
+        </value>
+        <value>703000
+        </value>
+        <value>650000
+        </value>
+        <value>500000
+        </value>
+    </array>
+    <array name="cpu.core_power.cluster0">
+        <value>105.3
+        </value>
+        <value>103.73
+        </value>
+        <value>101.7
+        </value>
+        <value>95.7
+        </value>
+        <value>73.51
+        </value>
+        <value>66
+        </value>
+        <value>57.87
+        </value>
+        <value>55.9
+        </value>
+        <value>55.2
+        </value>
+        <value>48.76
+        </value>
+        <value>46
+        </value>
+        <value>43
+        </value>
+        <value>38.97
+        </value>
+        <value>37.1
+        </value>
+        <value>36.4
+        </value>
+        <value>31.55
+        </value>
+    </array>
+    <array name="cpu.core_speeds.cluster1">
+        <value>2400000
+        </value>
+        <value>2306000
+        </value>
+        <value>2203000
+        </value>
+        <value>2118000
+        </value>
+        <value>1993000
+        </value>
+        <value>1837000
+        </value>
+        <value>1650000
+        </value>
+        <value>1534000
+        </value>
+        <value>1418000
+        </value>
+        <value>1274000
+        </value>
+        <value>1129000
+        </value>
+        <value>1042000
+        </value>
+        <value>985000
+        </value>
+        <value>898000
+        </value>
+        <value>840000
+        </value>
+        <value>725000
+        </value>
+    </array>
+    <array name="u.core_power.cluster1">
+        <value>201.7
+        </value>
+        <value>199.8
+        </value>
+        <value>195.6
+        </value>
+        <value>183.54
+        </value>
+        <value>181.8
+        </value>
+        <value>182.31
+        </value>
+        <value>180.39
+        </value>
+        <value>180.29
+        </value>
+        <value>179.59
+        </value>
+        <value>179.39
+        </value>
+        <value>180.1
+        </value>
+        <value>179.64
+        </value>
+        <value>178.93
+        </value>
+        <value>178.69
+        </value>
+        <value>178.41
+        </value>
+        <value>177.8
+        </value>
+    </array>
+    <item name="cpu.idle">5.4
+    </item>
+    <array name="memory.bandwidths">
+        <value>22.7
+        </value>
+    </array>
+    <item name="battery.capacity">5000
+    </item>
+    <item name="wifi.controller.idle">0
+    </item>
+    <item name="wifi.controller.rx">0
+    </item>
+    <item name="wifi.controller.tx">0
+    </item>
+    <array name="wifi.controller.tx_levels"/>
+    <item name="wifi.controller.voltage">0
+    </item>
+    <array name="wifi.batchedscan">
+        <value>.0002
+        </value>
+        <value>.002
+        </value>
+        <value>.02
+        </value>
+        <value>.2
+        </value>
+        <value>2
+        </value>
+    </array>
+    <item name="modem.controller.sleep">0
+    </item>
+    <item name="modem.controller.idle">0
+    </item>
+    <item name="modem.controller.rx">0
+    </item>
+    <array name="modem.controller.tx">
+        <value>0
+        </value>
+        <value>0
+        </value>
+        <value>0
+        </value>
+        <value>0
+        </value>
+        <value>0
+        </value>
+    </array>
+    <item name="modem.controller.voltage">0
+    </item>
+    <array name="gps.signalqualitybased">
+        <value>0
+        </value>
+        <value>0
+        </value>
+    </array>
+    <item name="gps.voltage">0
+    </item>
+</device>

--- a/overlay.mk
+++ b/overlay.mk
@@ -426,6 +426,7 @@ PRODUCT_PACKAGES += \
 	treble-overlay-xiaomi-redminote115g-systemui \
 	treble-overlay-xiaomi-redminote125g \
 	treble-overlay-xiaomi-redminote12pro5g \
+	treble-overlay-xiaomi-redminote135g \
 	treble-overlay-xiaomi-redminote13pro4g \
 	treble-overlay-xiaomi-redminote13pro4g-systemui \
 	treble-overlay-xiaomi-redminote5 \


### PR DESCRIPTION
Add overlay for Redmi Note 13 5G (gold)
Tested on EverestOS, everything works as expected.