### PR TITLE
motorola g72 - vicky

### DIFF
--- a/Moto/vicky/Android.mk
+++ b/Moto/vicky/Android.mk
@@ -1,0 +1,8 @@
+LOCAL_PATH := $(call my-dir)
+include $(CLEAR_VARS)
+LOCAL_MODULE_TAGS := optional
+LOCAL_PACKAGE_NAME := treble-overlay-moto-vicky
+LOCAL_MODULE_PATH := $(TARGET_OUT_PRODUCT)/overlay
+LOCAL_IS_RUNTIME_RESOURCE_OVERLAY := true
+LOCAL_PRIVATE_PLATFORM_APIS := true
+include $(BUILD_PACKAGE)

--- a/Moto/vicky/AndroidManifest.xml
+++ b/Moto/vicky/AndroidManifest.xml
@@ -1,0 +1,10 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+        package="me.phh.treble.overlay.motorola.vicky"
+        android:versionCode="1"
+        android:versionName="1.0">
+        <overlay android:targetPackage="android"
+        	android:requiredSystemPropertyName="ro.vendor.build.fingerprint"
+        	android:requiredSystemPropertyValue="+*motorola/vicky*"
+		android:priority="245"
+		android:isStatic="true" />
+</manifest>

--- a/Moto/vicky/res/values/config.xml
+++ b/Moto/vicky/res/values/config.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="config_device_volte_available">true</bool>
+    <bool name="config_device_vt_available">true</bool>
+    <bool name="config_device_wfc_ims_available">true</bool>
+    <bool name="config_dozeAfterScreenOff">true</bool>
+    <bool name="config_hotswapCapable">true</bool>
+    <bool name="config_powerDecoupleAutoSuspendModeFromDisplay">true</bool>
+    <bool name="config_powerDecoupleInteractiveModeFromDisplay">true</bool>
+    <bool name="config_setColorTransformAccelerated">true</bool>
+    <bool name="config_switch_phone_on_voice_reg_state_change">false</bool>
+    <bool name="config_useDevInputEventForAudioJack">true</bool>
+    <bool name="skip_restoring_network_selection">true</bool>
+
+    <integer name="config_bluetooth_operating_voltage_mv">3300</integer>
+    <integer name="config_screenBrightnessDoze">17</integer>
+
+    <string-array name="config_defaultPinnerServiceFiles">
+        <item>/system/framework/telephony-common.jar</item>
+        <item>/system/framework/services.jar</item>
+        <item>/system/framework/framework.jar</item>
+    </string-array>
+    <string-array name="config_tether_bluetooth_regexs">
+        <item>bt-pan</item>
+        <item>bt-dun</item>
+    </string-array>
+    <string-array name="config_tether_usb_regexs">
+        <item>rndis\\d</item>
+    </string-array>
+    <string-array name="config_tether_wifi_regexs">
+        <item>ap\\d</item>
+    </string-array>
+    <!-- I swear it makes sense to set config_udfps_sensor_props, and I can completely explain why. -->
+    <integer-array name="config_udfps_sensor_props">
+        <item>540</item>
+        <item>2164</item>
+        <item>91</item>
+    </integer-array>
+    <string-array name="networkAttributes">
+        <item>wifi,1,1,1,-1,true</item>
+        <item>mobile,0,0,0,-1,true</item>
+        <item>mobile_mms,2,0,2,60000,true</item>
+        <item>mobile_supl,3,0,2,60000,true</item>
+        <item>mobile_dun,4,0,2,60000,true</item>
+        <item>mobile_hipri,5,0,3,60000,true</item>
+        <item>ethernet,9,9,9,-1,true</item>
+        <item>mobile_fota,10,0,2,60000,true</item>
+        <item>mobile_ims,11,0,-1,-1,true</item>
+        <item>mobile_cbs,12,0,2,60000,true</item>
+        <item>wifi_p2p,13,1,0,-1,true</item>
+        <item>mobile_ia,14,0,2,-1,true</item>
+        <item>mobile_emergency,15,0,2,-1,true</item>
+        <item>mobile_mcx,1001,0,3,60000,true</item>
+        <item>mobile_xcap,1002,0,3,60000,true</item>
+        <item>mobile_rcs,2001,0,3,60000,true</item>
+        <item>mobile_bip,2002,0,3,60000,true</item>
+        <item>mobile_vsim,2003,0,-1,60000,true</item>
+    </string-array>
+</resources>

--- a/overlay.mk
+++ b/overlay.mk
@@ -133,6 +133,7 @@ PRODUCT_PACKAGES += \
 	treble-overlay-moto-tesla-systemui \
 	treble-overlay-moto-tundra \
 	treble-overlay-moto-tundra-systemui \
+	treble-overlay-moto-vicky \
 	treble-overlay-mtk-ims \
 	treble-overlay-nokia-b2n-7plus \
 	treble-overlay-nokia-ctl-7-1 \


### PR DESCRIPTION
Done using [this guide](https://github.com/TrebleDroid/treble_experimentations/wiki/How-to-create-an-overlay%3F) and files taken straight from a moto g72 I own running stock rom updated to latest.

Tested against [iode 14](https://gitlab.iode.tech/ota/release/-/blob/master/gsi/iode-5.11-20250401-arm64_ab.img.xz).

### Using kernelsu module (I have kernel su installed) and dsu sideloader:

module.prop
```
id=treble_vicky
name=Treble vicky
version=1
versionCode=1
author=zenxarch
description=Install treble vicky
```

and `system / product / overlay / treble-overlay-moto-vicky.apk`

Result:
Under display fingerprint ui shows up correct
but cannot enroll fingerprint.

Gsi compat in general with treble droid:
Working calls + 4g
bluetooth working