### PR TITLE
feat(lenovo): add overlay for Lenovo TB710FU

### DIFF
--- a/Lenovo/TB710FU/Android.mk
+++ b/Lenovo/TB710FU/Android.mk
@@ -1,0 +1,8 @@
+LOCAL_PATH := $(call my-dir)
+include $(CLEAR_VARS)
+LOCAL_MODULE_TAGS := optional
+LOCAL_PACKAGE_NAME := treble-overlay-lenovo-tb710fu
+LOCAL_MODULE_PATH := $(TARGET_OUT_PRODUCT)/overlay
+LOCAL_IS_RUNTIME_RESOURCE_OVERLAY := true
+LOCAL_PRIVATE_PLATFORM_APIS := true
+include $(BUILD_PACKAGE)

--- a/Lenovo/TB710FU/AndroidManifest.xml
+++ b/Lenovo/TB710FU/AndroidManifest.xml
@@ -1,0 +1,10 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+        package="me.phh.treble.overlay.lenovo.TB710FU"
+        android:versionCode="1"
+        android:versionName="1.0">
+        <overlay android:targetPackage="android"
+        	android:requiredSystemPropertyName="ro.product.vendor.device"
+        	android:requiredSystemPropertyValue="TB710FU"
+		android:priority="370"
+		android:isStatic="true" />
+</manifest>

--- a/Lenovo/TB710FU/res/values/config.xml
+++ b/Lenovo/TB710FU/res/values/config.xml
@@ -1,0 +1,192 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="config_automatic_brightness_available">true</bool>
+    <bool name="config_setColorTransformAccelerated">true</bool>
+    <integer-array name="config_autoBrightnessLevels">
+        <item>4</item>
+        <item>5</item>
+        <item>14</item>
+        <item>15</item>
+        <item>39</item>
+        <item>40</item>
+        <item>99</item>
+        <item>100</item>
+        <item>179</item>
+        <item>180</item>
+        <item>399</item>
+        <item>400</item>
+        <item>549</item>
+        <item>550</item>
+        <item>999</item>
+        <item>1000</item>
+        <item>1499</item>
+        <item>1500</item>
+        <item>1999</item>
+        <item>2000</item>
+        <item>2499</item>
+        <item>2500</item>
+        <item>2999</item>
+        <item>3000</item>
+        <item>3999</item>
+        <item>4000</item>
+        <item>10000</item>
+        <item>10001</item>
+    </integer-array>
+    <integer-array name="config_autoBrightnessDisplayValuesNits">
+        <item>8</item>
+        <item>8</item>
+        <item>30</item>
+        <item>30</item>
+        <item>70</item>
+        <item>70</item>
+        <item>100</item>
+        <item>100</item>
+        <item>120</item>
+        <item>120</item>
+        <item>150</item>
+        <item>150</item>
+        <item>180</item>
+        <item>180</item>
+        <item>210</item>
+        <item>210</item>
+        <item>270</item>
+        <item>270</item>
+        <item>340</item>
+        <item>340</item>
+        <item>420</item>
+        <item>420</item>
+        <item>480</item>
+        <item>480</item>
+        <item>550</item>
+        <item>550</item>
+        <item>650</item>
+        <item>650</item>
+        <item>800</item>
+    </integer-array>
+    <integer-array name="config_screenBrightnessBacklight">
+        <item>0</item>
+        <item>3</item>
+        <item>10</item>
+        <item>22</item>
+        <item>32</item>
+        <item>38</item>
+        <item>48</item>
+        <item>57</item>
+        <item>67</item>
+        <item>86</item>
+        <item>108</item>
+        <item>134</item>
+        <item>153</item>
+        <item>175</item>
+        <item>194</item>
+        <item>255</item>
+    </integer-array>
+    <integer-array name="config_screenBrightnessNits">
+        <item>0</item>
+        <item>8</item>
+        <item>30</item>
+        <item>70</item>
+        <item>100</item>
+        <item>120</item>
+        <item>150</item>
+        <item>180</item>
+        <item>210</item>
+        <item>270</item>
+        <item>340</item>
+        <item>420</item>
+        <item>480</item>
+        <item>550</item>
+        <item>650</item>
+        <item>800</item>
+    </integer-array>
+    <integer name="config_autoBrightnessBrighteningLightDebounce">2000</integer>
+    <integer name="config_autoBrightnessDarkeningLightDebounce">3000</integer>
+    <integer name="config_brightness_ramp_rate_fast">160</integer>
+    <integer name="config_screenBrightnessSettingDefault">102</integer>
+    <integer name="config_screenBrightnessSettingMinimum">1</integer>
+    <item type="dimen" name="config_screenBrightnessSettingDefaultFloat">0.4</item>
+    <item type="dimen" name="config_screenBrightnessSettingMaximumFloat">1.0</item>
+    <item type="dimen" name="config_screenBrightnessSettingMinimumFloat">0.0019311</item>
+    <dimen name="status_bar_height">24.0dip</dimen>
+    <dimen name="status_bar_height_default">24.0dip</dimen>
+    <dimen name="status_bar_height_landscape">24.0dip</dimen>
+    <dimen name="status_bar_height_portrait">24.0dip</dimen>
+    <string name="config_displayLightSensorType">defaultlightsensor</string>
+    <integer-array name="config_availableColorModes">
+        <item>0</item>
+        <item>1</item>
+        <item>3</item>
+        <item>256</item>
+        <item>257</item>
+        <item>258</item>
+        <item>259</item>
+        <item>260</item>
+        <item>261</item>
+        <item>262</item>
+        <item>263</item>
+        <item>264</item>
+        <item>265</item>
+    </integer-array>
+    <bool name="config_dozeAlwaysOnDisplayAvailable">false</bool>
+    <bool name="config_dozeAfterScreenOff">true</bool>
+    <bool name="config_dreamsEnabledByDefault">false</bool>
+    <integer name="config_screenBrightnessDoze">17</integer>
+    <string name="config_dozeComponent">com.android.systemui/com.android.systemui.doze.DozeService</string>
+    <bool name="config_powerDecoupleInteractiveModeFromDisplay">false</bool>
+    <bool name="config_unplugTurnsOnScreen">true</bool>
+    <integer name="device_idle_min_deep_maintenance_time_ms">10000</integer>
+    <bool name="config_keyguardUserSwitcher">true</bool>
+    <bool name="config_supportAudioSourceUnprocessed">true</bool>
+    <bool name="config_camera_sound_forced">false</bool>
+    <bool name="config_bluetooth_hfp_inband_ringing_support">true</bool>
+    <bool name="config_bluetooth_le_peripheral_mode_supported">true</bool>
+    <bool name="config_wifiDisplaySupportsProtectedBuffers">true</bool>
+    <bool name="config_wifi_background_scan_support">true</bool>
+    <bool name="config_wifi_batched_scan_supported">true</bool>
+    <bool name="config_wifi_connected_mac_randomization_supported">true</bool>
+    <bool name="config_wifi_dual_band_support">true</bool>
+    <bool name="config_wifi_p2p_mac_randomization_supported">true</bool>
+    <bool name="config_wifi_softap_acs_supported">true</bool>
+    <bool name="config_wifi_softap_ieee80211ac_supported">true</bool>
+    <string-array name="config_tether_usb_regexs">
+        <item>usb\\d</item>
+        <item>rndis\\d</item>
+    </string-array>
+    <string-array name="config_tether_wifi_regexs">
+        <item>softap0</item>
+        <item>wlan0</item>
+    </string-array>
+    <string-array name="config_tether_bluetooth_regexs">
+        <item>bnep\\d</item>
+        <item>bt-pan</item>
+    </string-array>
+    <string-array name="config_tether_dhcp_range">
+        <item>192.168.42.2</item>
+        <item>192.168.42.254</item>
+        <item>192.168.43.2</item>
+        <item>192.168.43.254</item>
+        <item>192.168.44.2</item>
+        <item>192.168.44.254</item>
+        <item>192.168.45.2</item>
+        <item>192.168.45.254</item>
+        <item>192.168.46.2</item>
+        <item>192.168.46.254</item>
+        <item>192.168.47.2</item>
+        <item>192.168.47.254</item>
+        <item>192.168.48.2</item>
+        <item>192.168.48.254</item>
+        <item>192.168.49.2</item>
+        <item>192.168.49.254</item>
+        <item>192.168.50.2</item>
+        <item>192.168.50.254</item>
+        <item>192.168.51.2</item>
+        <item>192.168.51.254</item>
+    </string-array>
+    <integer-array name="config_tether_upstream_types">
+        <item>1</item>
+        <item>5</item>
+        <item>7</item>
+    </integer-array>
+    <string name="config_optionalPackageVerifierName">seemp.service</string>
+    <string name="config_persistentDataPackageName">com.google.android.gms</string>
+</resources>


### PR DESCRIPTION
This PR introduces the framework overlay for the Lenovo TB710FU (Lenovo Tab M9) to ensure proper hardware-to-framework translation on GSIs.

# Included Configurations:

- Detailed config_autoBrightnessLevels and config_autoBrightnessDisplayValuesNits arrays for accurate automatic brightness scaling.
- Mapped physical backlight limits (config_screenBrightnessBacklight and config_screenBrightnessNits).
- Defined default status bar heights for both portrait and landscape orientations (24.0dip).
- Configured standard power, Doze, and tethering framework flags specific to the device.

# Additional Context:

Built and verified working against modern GSI environments.

Note: A separate PR https://github.com/TrebleDroid/device_phh_treble/pull/85 is submitted to  https://github.com/TrebleDroid/device_phh_treble  to map the proprietary hall_irq keys (252/253) to standard SLEEP/WAKEUP events for the magnetic smart cover to function properly.