### PR TITLE
samsung a04s: add systemui and regular overlays

### DIFF
--- a/Samsung/A04s-SystemUI/Android.mk
+++ b/Samsung/A04s-SystemUI/Android.mk
@@ -1,0 +1,8 @@
+LOCAL_PATH := $(call my-dir)
+include $(CLEAR_VARS)
+LOCAL_MODULE_TAGS := optional
+LOCAL_PACKAGE_NAME := treble-overlay-samsung-a04s-systemui
+LOCAL_MODULE_PATH := $(TARGET_OUT_PRODUCT)/overlay
+LOCAL_IS_RUNTIME_RESOURCE_OVERLAY := true
+LOCAL_PRIVATE_PLATFORM_APIS := true
+include $(BUILD_PACKAGE)

--- a/Samsung/A04s-SystemUI/AndroidManifest.xml
+++ b/Samsung/A04s-SystemUI/AndroidManifest.xml
@@ -1,0 +1,10 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+        package="me.phh.treble.overlay.samsung.a04s.systemui"
+        android:versionCode="1"
+        android:versionName="1.0">
+        <overlay android:targetPackage="com.android.systemui"
+        	android:requiredSystemPropertyName="ro.vendor.build.fingerprint"
+        	android:requiredSystemPropertyValue="+*samsung/a04s*"
+		android:priority="296"
+		android:isStatic="true" />
+</manifest>

--- a/Samsung/A04s-SystemUI/res/values/config.xml
+++ b/Samsung/A04s-SystemUI/res/values/config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+	<dimen name="status_bar_clock_starting_padding">7dp</dimen>
+	<dimen name="status_bar_padding_end">8dp</dimen>
+	<dimen name="status_bar_padding_start">8dp</dimen>
+</resources>

--- a/Samsung/A04s/Android.mk
+++ b/Samsung/A04s/Android.mk
@@ -1,0 +1,8 @@
+LOCAL_PATH := $(call my-dir)
+include $(CLEAR_VARS)
+LOCAL_MODULE_TAGS := optional
+LOCAL_PACKAGE_NAME := treble-overlay-samsung-a04s
+LOCAL_MODULE_PATH := $(TARGET_OUT_PRODUCT)/overlay
+LOCAL_IS_RUNTIME_RESOURCE_OVERLAY := true
+LOCAL_PRIVATE_PLATFORM_APIS := true
+include $(BUILD_PACKAGE)

--- a/Samsung/A04s/AndroidManifest.xml
+++ b/Samsung/A04s/AndroidManifest.xml
@@ -1,0 +1,10 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+        package="me.phh.treble.overlay.samsung.a04s"
+        android:versionCode="1"
+        android:versionName="1.0">
+        <overlay android:targetPackage="android"
+        	android:requiredSystemPropertyName="ro.vendor.build.fingerprint"
+        	android:requiredSystemPropertyValue="+*samsung/a04s*"
+		android:priority="622"
+		android:isStatic="true" />
+</manifest>

--- a/Samsung/A04s/res/values/config.xml
+++ b/Samsung/A04s/res/values/config.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <integer-array name="config_autoBrightnessLcdBacklightValues">
+        <item>6</item>
+        <item>29</item>
+        <item>53</item>
+        <item>75</item>
+        <item>91</item>
+        <item>107</item>
+        <item>134</item>
+        <item>155</item>
+        <item>172</item>
+        <item>211</item>
+        <item>255</item>
+        <item>306</item>
+    </integer-array>
+    <integer-array name="config_autoBrightnessLevels">
+        <item>30</item>
+        <item>50</item>
+        <item>70</item>
+        <item>100</item>
+        <item>200</item>
+        <item>300</item>
+        <item>500</item>
+        <item>700</item>
+        <item>1000</item>
+        <item>1500</item>
+        <item>3000</item>
+    </integer-array>
+    <string name="config_mainBuiltInDisplayCutout">M 0,0 H -46.93333333333333 V 24 H 46.93333333333333 V 0 H 0 Z @dp</string>
+    <bool name="config_supportAudioSourceUnprocessed">false</bool>
+    <bool name="config_automatic_brightness_available">true</bool>
+    <item type="dimen" name="config_screenBrightnessSettingDefaultFloat">0.5019608</item>
+    <item type="dimen" name="config_screenBrightnessSettingMaximumFloat">1.0</item>
+    <item type="dimen" name="config_screenBrightnessSettingMinimumFloat">0.003921569</item>
+    <dimen name="status_bar_height_portrait">4.529999mm</dimen>
+    <integer name="config_screenBrightnessDark">1</integer>
+    <integer name="config_screenBrightnessDim">6</integer>
+    <integer name="config_screenBrightnessSettingDefault">128</integer>
+    <integer name="config_screenBrightnessSettingMaximum">255</integer>
+    <integer name="config_screenBrightnessSettingMinimum">1</integer>
+</resources>

--- a/Samsung/A04s/res/xml/power_profile.xml
+++ b/Samsung/A04s/res/xml/power_profile.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="utf-8"?>
+<device name="Android">
+    <item name="none">0</item>
+    <item name="screen.on">68</item>
+    <item name="screen.full">279.4</item>
+    <item name="audio">26.8</item>
+    <item name="video">25</item>
+    <item name="camera.avg">164.25</item>
+    <item name="camera.flashlight">48.52</item>
+    <item name="radio.scanning">55.2</item>
+    <array name="radio.on">
+        <value>1.88</value>
+        <value>1.88</value>
+    </array>
+    <item name="modem.controller.sleep">0</item>
+    <item name="modem.controller.idle">83</item>
+    <item name="modem.controller.rx">92</item>
+    <array name="modem.controller.tx">
+        <value>132</value>
+        <value>157</value>
+        <value>214</value>
+        <value>331</value>
+        <value>398</value>
+    </array>
+    <item name="modem.controller.voltage">3700</item>
+    <item name="wifi.controller.idle">1</item>
+    <item name="wifi.controller.rx">38</item>
+    <item name="wifi.controller.tx">345</item>
+    <array name="wifi.controller.tx_levels">
+        <value>0</value>
+    </array>
+    <item name="wifi.controller.voltage">3600</item>
+    <array name="wifi.batchedscan">
+        <value>.0002</value>
+        <value>.002</value>
+        <value>.02</value>
+        <value>.2</value>
+        <value>2</value>
+    </array>
+    <item name="gps.on">49</item>
+    <item name="bluetooth.controller.idle">1</item>
+    <item name="bluetooth.controller.rx">15</item>
+    <item name="bluetooth.controller.tx">55</item>
+    <item name="bluetooth.controller.voltage">3600</item>
+    <item name="cpu.suspend">3.37</item>
+    <item name="cpu.idle">15.2</item>
+    <array name="cpu.clusters.cores">
+        <value>4</value>
+        <value>4</value>
+    </array>
+    <array name="cpu.core_speeds.cluster0">
+        <value>546000</value>
+        <value>650000</value>
+        <value>806000</value>
+        <value>949000</value>
+        <value>1053000</value>
+        <value>1157000</value>
+        <value>1300000</value>
+        <value>1456000</value>
+        <value>1586000</value>
+        <value>1742000</value>
+        <value>1846000</value>
+        <value>2002000</value>
+    </array>
+    <array name="cpu.core_power.cluster0">
+        <value>16.6</value>
+        <value>18.2</value>
+        <value>21.4</value>
+        <value>24.1</value>
+        <value>27.0</value>
+        <value>30.5</value>
+        <value>39.6</value>
+        <value>46.7</value>
+        <value>53.4</value>
+        <value>65.7</value>
+        <value>76.8</value>
+        <value>95.7</value>
+    </array>
+    <array name="cpu.core_speeds.cluster1">
+        <value>546000</value>
+        <value>650000</value>
+        <value>806000</value>
+        <value>949000</value>
+        <value>1053000</value>
+        <value>1157000</value>
+        <value>1300000</value>
+        <value>1456000</value>
+        <value>1586000</value>
+        <value>1742000</value>
+        <value>1846000</value>
+        <value>2002000</value>
+    </array>
+    <array name="cpu.core_power.cluster1">
+        <value>16.6</value>
+        <value>18.2</value>
+        <value>21.4</value>
+        <value>24.1</value>
+        <value>27.0</value>
+        <value>30.5</value>
+        <value>39.6</value>
+        <value>46.7</value>
+        <value>53.4</value>
+        <value>65.7</value>
+        <value>76.8</value>
+        <value>95.7</value>
+    </array>
+    <array name="gpu.active">
+        <value>42.9</value>
+        <value>50.1</value>
+        <value>69.8</value>
+        <value>91.9</value>
+        <value>123.6</value>
+        <value>159.5</value>
+    </array>
+    <array name="gpu.speeds">
+        <value>377000</value>
+        <value>433000</value>
+        <value>598000</value>
+        <value>754000</value>
+        <value>865000</value>
+        <value>1001000</value>
+    </array>
+    <item name="battery.capacity">4900</item>
+    <item name="battery.typical.capacity">5000</item>
+</device>

--- a/overlay.mk
+++ b/overlay.mk
@@ -238,6 +238,8 @@ PRODUCT_PACKAGES += \
 	treble-overlay-samsung-a02q \
 	treble-overlay-samsung-a02q-systemui \
 	treble-overlay-samsung-a03 \
+	treble-overlay-samsung-a04s \
+	treble-overlay-samsung-a04s-systemui \
 	treble-overlay-samsung-a10s \
 	treble-overlay-samsung-a20 \
 	treble-overlay-samsung-a20s \


### PR DESCRIPTION
Overlays for Galaxy A04s (SM-A047F)

Mainly diffing vendor and product, gsi systemui and samsung's systemui.

Auto brightness probably doesn't work even if this overlay enables it because there is no dedicated light sensor, stock uses a custom CameraLightSensorService to get the light info from camera.