### PR TITLE
Add OnePlus 9 Pro lemonadep overlay

### DIFF
--- a/OnePlus/lemonadep/Android.mk
+++ b/OnePlus/lemonadep/Android.mk
@@ -1,0 +1,8 @@
+LOCAL_PATH := $(call my-dir)
+include $(CLEAR_VARS)
+LOCAL_MODULE_TAGS := optional
+LOCAL_PACKAGE_NAME := treble-overlay-oneplus-lemonadep
+LOCAL_MODULE_PATH := $(TARGET_OUT_PRODUCT)/overlay
+LOCAL_IS_RUNTIME_RESOURCE_OVERLAY := true
+LOCAL_PRIVATE_PLATFORM_APIS := true
+include $(BUILD_PACKAGE)

--- a/OnePlus/lemonadep/AndroidManifest.xml
+++ b/OnePlus/lemonadep/AndroidManifest.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="me.phh.treble.overlay.oneplus.lemonadep"
+    android:versionCode="1"
+    android:versionName="1.0">
+
+    <overlay
+        android:targetPackage="android"
+        android:requiredSystemPropertyName="ro.boot.prjname"
+        android:requiredSystemPropertyValue="+(19815)"
+        android:priority="2085"
+        android:isStatic="true" />
+
+</manifest>

--- a/OnePlus/lemonadep/res/values/config.xml
+++ b/OnePlus/lemonadep/res/values/config.xml
@@ -1,0 +1,111 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <integer-array name="config_autoBrightnessLcdBacklightValues">
+    <item>10</item>
+    <item>20</item>
+    <item>40</item>
+    <item>70</item>
+    <item>110</item>
+    <item>160</item>
+    <item>200</item>
+    <item>255</item>
+  </integer-array>
+  <integer-array name="config_autoBrightnessLevels">
+    <item>10</item>
+    <item>30</item>
+    <item>60</item>
+    <item>100</item>
+    <item>150</item>
+    <item>210</item>
+    <item>255</item>
+  </integer-array>
+  <integer-array name="config_availableColorModes">
+    <item>0</item>
+    <item>1</item>
+    <item>3</item>
+    <item>256</item>
+    <item>257</item>
+    <item>258</item>
+    <item>259</item>
+    <item>260</item>
+    <item>261</item>
+    <item>262</item>
+    <item>263</item>
+    <item>264</item>
+    <item>265</item>
+  </integer-array>
+  <string-array name="config_mobile_tcp_buffers">
+    <item>5gnr:2097152,6291456,16777216,512000,2097152,8388608</item>
+    <item>lte:2097152,4194304,8388608,262144,524288,1048576</item>
+    <item>lte_ca:4096,6291456,12582912,4096,1048576,4194304</item>
+    <item>umts:4094,87380,1220608,4096,16384,1220608</item>
+    <item>hspa:4094,87380,1220608,4096,16384,1220608</item>
+    <item>hsupa:4094,87380,1220608,4096,16384,1220608</item>
+    <item>hsdpa:4094,87380,1220608,4096,16384,1220608</item>
+    <item>hspap:4094,87380,1220608,4096,16384,1220608</item>
+    <item>edge:4093,26280,35040,4096,16384,35040</item>
+    <item>gprs:4092,8760,11680,4096,8760,11680</item>
+    <item>evdo:4094,87380,524288,4096,16384,262144</item>
+  </string-array>
+  <string-array name="config_tether_bluetooth_regexs">
+    <item>bnep\\d</item>
+    <item>bt-pan</item>
+  </string-array>
+  <integer-array name="config_tether_upstream_types">
+    <item>0</item>
+    <item>1</item>
+    <item>5</item>
+    <item>7</item>
+  </integer-array>
+  <string-array name="config_tether_usb_regexs">
+    <item>usb\\d</item>
+    <item>rndis\\d</item>
+  </string-array>
+  <string-array name="config_tether_wifi_regexs">
+    <item>softap0</item>
+    <item>wlan0</item>
+  </string-array>
+  <string-array name="networkAttributes">
+    <item>wifi,1,1,1,-1,true</item>
+    <item>mobile,0,0,0,-1,true</item>
+    <item>mobile_mms,2,0,4,60000,true</item>
+    <item>mobile_supl,3,0,2,60000,true</item>
+    <item>mobile_dun,4,0,2,60000,true</item>
+    <item>mobile_hipri,5,0,3,60000,true</item>
+    <item>mobile_fota,10,0,2,60000,true</item>
+    <item>mobile_ims,11,0,2,60000,true</item>
+    <item>mobile_cbs,12,0,2,60000,true</item>
+    <item>bluetooth,7,7,2,-1,true</item>
+    <item>mobile_emergency,15,0,5,-1,true</item>
+    <item>ethernet,9,9,9,-1,true</item>
+  </string-array>
+  <string-array name="radioAttributes">
+    <item>1,1</item>
+    <item>0,1</item>
+    <item>7,1</item>
+  </string-array>
+  <bool name="config_automatic_brightness_available">true</bool>
+  <bool name="config_bluetooth_hfp_inband_ringing_support">true</bool>
+  <bool name="config_bluetooth_le_peripheral_mode_supported">true</bool>
+  <bool name="config_carrier_volte_available">true</bool>
+  <bool name="config_device_volte_available">true</bool>
+  <bool name="config_device_vt_available">true</bool>
+  <bool name="config_device_wfc_ims_available">true</bool>
+  <bool name="config_dozeAfterScreenOff">true</bool>
+  <bool name="config_hotswapCapable">true</bool>
+  <bool name="config_powerDecoupleInteractiveModeFromDisplay">false</bool>
+  <bool name="config_setColorTransformAccelerated">true</bool>
+  <bool name="config_speed_up_audio_on_mt_calls">true</bool>
+  <bool name="config_supportAudioSourceUnprocessed">true</bool>
+  <bool name="config_switch_phone_on_voice_reg_state_change">false</bool>
+  <bool name="config_wifiDisplaySupportsProtectedBuffers">true</bool>
+  <bool name="config_wifi_background_scan_support">true</bool>
+  <bool name="config_wifi_batched_scan_supported">true</bool>
+  <bool name="config_wifi_connected_mac_randomization_supported">true</bool>
+  <bool name="config_wifi_dual_band_support">true</bool>
+  <bool name="config_wifi_p2p_mac_randomization_supported">true</bool>
+  <bool name="skip_restoring_network_selection">true</bool>
+  <integer name="config_defaultPeakRefreshRate">240</integer>
+  <integer name="config_defaultRefreshRate">0</integer>
+  <integer name="config_screenBrightnessDoze">17</integer>
+</resources>

--- a/overlay.mk
+++ b/overlay.mk
@@ -160,6 +160,7 @@ PRODUCT_PACKAGES += \
 	treble-overlay-oneplus-ace3v-systemui \
 	treble-overlay-oneplus-acepro \
 	treble-overlay-oneplus-acepro-systemui \
+	treble-overlay-oneplus-lemonadep \
 	treble-overlay-oneplus-n10 \
 	treble-overlay-oneplus-n10-systemui \
 	treble-overlay-oneplus-n2 \


### PR DESCRIPTION
Adds a dedicated hardware overlay for the OnePlus 9 Pro (lemonadep) using ro.boot.prjname project ID 19815.

Changes:
- add OnePlus/lemonadep/AndroidManifest.xml
- add OnePlus/lemonadep/Android.mk
- add OnePlus/lemonadep/res/values/config.xml
- register treble-overlay-oneplus-lemonadep in overlay.mk

The resource set was derived from stock OxygenOS 14 framework resource overlays and reduced to TrebleDroid-compatible keys. Local validation included git diff --cached --check and a successful local APK build/sign verification.